### PR TITLE
Fix: Resolve template not found error for includes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,8 @@ export function activate(context: vscode.ExtensionContext) {
             console.log("Jinjer: 📢 Loaded context data:", contextData);
             const templateContent = activeDocument.getText();
 
-            const env = nunjucks.configure({
+            const templateDir = path.dirname(activeDocument.fileName);
+            const env = nunjucks.configure(templateDir, {
                 autoescape: true,
                 trimBlocks: false,
                 lstripBlocks: false

--- a/test_templates/included.j2
+++ b/test_templates/included.j2
@@ -1,0 +1,1 @@
+Hello from included.j2

--- a/test_templates/main.j2
+++ b/test_templates/main.j2
@@ -1,0 +1,2 @@
+Hello from main.j2
+{% include 'included.j2' %}


### PR DESCRIPTION
Fixes #1 
Previously, the Nunjucks environment was not configured with a search path for templates, leading to errors when using the `{% include %}` tag.

This commit fixes the issue by:
- Getting the directory of the active document.
- Passing this directory to `nunjucks.configure()` as the search path.

This allows Nunjucks to correctly locate and render included templates that are in the same directory as the parent template.