### PR TITLE
feat: Implement context file inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.7] - 2025-06-12
 
 - fixes bug #3
+
+## [0.0.10] - 2025-06-13
+
+- fixes bug #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.7] - 2025-06-12
 
 - fixes bug #3
+
+## [0.0.8] - 2025-06-12
+
+- fixes bug #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,3 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.7] - 2025-06-12
 
 - fixes bug #3
-
-## [0.0.8] - 2025-06-12
-
-- fixes bug #5

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ You can configure the following settings directly in your VS Code `settings.json
 * **`jinjer.settingsFile`**:
   * Description: Defines the name of the JSON file to be used for per-workspace Jinjer settings. This file allows for more granular, project-specific configurations that can be version-controlled.
   * Default: `".jinjer-settings.json"`
+* **`jinjer.contextIncludeKey`**:
+  * Description: Specifies a key within your JSON/YAML context files that lists other context files to be included and merged. Paths are resolved relative to the file containing this key, or can be absolute. Set to a string like `"_jinjer_include_contexts"` (default) or `null`/empty string to disable.
+  * Default: `"_jinjer_include_contexts"`
 
 ### Per-Workspace Settings File
 
@@ -79,6 +82,83 @@ This JSON file can contain the following properties:
 * **Project-Specific Configurations**: Tailor Jinjer's behavior to the specific needs and directory structure of each project.
 * **Team Collaboration**: Share consistent rendering settings across a team by committing this file to version control.
 * **Simplified Setup**: New contributors can get started quickly with pre-defined project settings, ensuring consistent preview behavior.
+
+### Including Other Context Files
+
+To better organize and reuse context data, Jinjer allows you to include other context files from within a primary context file. This feature is controlled by the `jinjer.contextIncludeKey` setting.
+
+By default, if your context file (e.g., `.jinjer.json`) contains a key named `_jinjer_include_contexts` (or whatever you've configured `jinjer.contextIncludeKey` to be), the extension will look for an array of file paths under that key. These specified files will be read, parsed (as JSON or YAML based on their extension), and their content will be deep-merged into the parent context.
+
+**Example:**
+
+Suppose `jinjer.contextIncludeKey` is set to its default, `"_jinjer_include_contexts"`.
+
+Your main context file, e.g., `template.context.json`:
+```json
+{
+  "pageTitle": "My Awesome Page",
+  "featureFlags": {
+    "newNav": true,
+    "betaFeature": false
+  },
+  "_jinjer_include_contexts": [
+    "../shared/site-common.json",
+    "override-settings.yaml"
+  ],
+  "specificValue": "This is from the main context file."
+}
+```
+
+`../shared/site-common.json`:
+```json
+{
+  "siteName": "Our Cool Site",
+  "featureFlags": {
+    "betaFeature": true,
+    "analytics": true
+  }
+}
+```
+
+`override-settings.yaml`:
+```yaml
+featureFlags:
+  newNav: false # This will override the value from main context
+contactEmail: support@example.com
+```
+
+**Resulting Merged Context:**
+```json
+{
+  "pageTitle": "My Awesome Page",
+  "featureFlags": {
+    "newNav": false,       // from override-settings.yaml
+    "betaFeature": true,   // from site-common.json (merged first, then override-settings.yaml, but site-common had it last for this key) - actually, it should be from site-common.
+                           // Correction: parent -> include1 -> include2. So override-settings.yaml's betaFeature: true would be overridden by site-common.json if order was swapped.
+                           // With current order: parent -> site-common -> override.
+                           // parent.newNav=true. site-common has no newNav. override.newNav=false. So newNav=false.
+                           // parent.betaFeature=false. site-common.betaFeature=true. override has no betaFeature. So betaFeature=true.
+    "analytics": true      // from site-common.json
+  },
+  "siteName": "Our Cool Site", // from site-common.json
+  "contactEmail": "support@example.com", // from override-settings.yaml
+  "specificValue": "This is from the main context file.",
+  "_jinjer_include_contexts": [ // This key also remains, as per current merge logic
+    "../shared/site-common.json",
+    "override-settings.yaml"
+  ]
+}
+```
+*(The example merge logic for `featureFlags.betaFeature` was slightly off in the thought process, the final JSON reflects the correct last-win outcome based on include order)*
+
+**Key Behaviors:**
+
+*   **Path Resolution:** Paths to included files are resolved relative to the directory of the file containing the include directive. Absolute paths are also supported and used as-is.
+*   **Deep Merging:** Included files are deep-merged into the parent context. Merging occurs sequentially based on the order in the include array.
+*   **Conflict Resolution:** If multiple files (including the parent) define the same key, the value from the file processed later takes precedence (i.e., includes overwrite the parent, and later includes overwrite earlier ones for the same keys at the same level).
+*   **File Types:** Both JSON and YAML files can be included, regardless of the parent file's type. The extension determines the type based on the included file's extension (`.json`, `.yaml`, `.yml`).
+*   **Circular Dependencies:** Circular includes (e.g., File A includes File B, and File B includes File A) are detected and handled by not re-processing a file that is already in the current chain of includes. A warning is logged in such cases.
+*   **Disabling:** Setting `jinjer.contextIncludeKey` to `null` or an empty string will disable this feature.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can configure the following settings directly in your VS Code `settings.json
   * Description: Defines the name of the JSON file to be used for per-workspace Jinjer settings. This file allows for more granular, project-specific configurations that can be version-controlled.
   * Default: `".jinjer-settings.json"`
 * **`jinjer.contextIncludeKey`**:
-  * Description: Specifies a key within your JSON/YAML context files that lists other context files to be included and merged. Paths are resolved relative to the file containing this key, or can be absolute. Set to a string like `"_jinjer_include_contexts"` (default) or `null`/empty string to disable.
+  * Description: Specifies a key within your JSON/YAML context files that lists other context files to be included and merged. Paths are resolved relative to the file containing this key, or can be absolute. Set to a string like `"_jinjer_include_contexts"` (default) or `null`/empty string to disable. This setting can also be specified in a `.jinjer-settings.json` file within your workspace, and the value in `.jinjer-settings.json` will take precedence.
   * Default: `"_jinjer_include_contexts"`
 
 ### Per-Workspace Settings File
@@ -63,6 +63,10 @@ This JSON file can contain the following properties:
   * Description: A path or an array of paths (relative to the workspace root) where Nunjucks should look for templates during `{% include %}`, `{% extends %}`, or `{% import %}` operations. These paths are added to Nunjucks's search list. This overrides the `jinjer.customSearchPath` from VS Code settings.
   * Example (single path): `"templates/includes"`
   * Example (multiple paths): `["includes/", "shared_components/jinja"]`
+* **`contextIncludeKey`**:
+  * Type: `string | null`
+  * Description: Specifies the key name within context files that holds an array of other context file paths to include and merge. Paths are relative to the file containing this key, or can be absolute. Setting to `null` or an empty string disables the include feature for contexts loaded via this workspace settings file. This overrides the `jinjer.contextIncludeKey` from VS Code's global or user/workspace settings.
+  * Example: `"_custom_includes_key"` or `null`
 
 #### Example `.jinjer-settings.json`
 
@@ -73,7 +77,8 @@ This JSON file can contain the following properties:
   "customSearchPath": [
     "src/templates/includes",
     "src/templates/layouts"
-  ]
+  ],
+  "contextIncludeKey": "_another_include_key"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
           "type": "string",
           "default": ".jinjer-settings.json",
           "description": "The name of the per-workspace settings file (JSON). This file allows to override global Jinjer settings on a per-workspace basis."
+        },
+        "jinjer.contextIncludeKey": {
+          "type": ["string", "null"],
+          "default": "_jinjer_include_contexts",
+          "description": "The key in context files (JSON/YAML) that specifies an array of other context file paths to include and merge. Paths are relative to the file containing this key. Set to null or empty string to disable."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "jinjer.contextIncludeKey": {
           "type": ["string", "null"],
           "default": "_jinjer_include_contexts",
-          "description": "The key in context files (JSON/YAML) that specifies an array of other context file paths to include and merge. Paths are relative to the file containing this key. Set to null or empty string to disable."
+          "description": "The key in context files (JSON/YAML) that specifies an array of other context file paths to include and merge. Paths are relative to the file containing this key. Set to null or empty string to disable. This VS Code setting can be overridden for a specific workspace by defining `contextIncludeKey` (using the same value types) in the `.jinjer-settings.json` file."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "jinjer",
   "icon": "logo.png",
   "description": "Jinja2 Previewer - Now with more features!",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "engines": {
     "vscode": "^1.100.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "jinjer",
   "icon": "logo.png",
   "description": "Jinja2 Previewer - Now with more features!",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.100.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "jinjer",
   "icon": "logo.png",
   "description": "Jinja2 Previewer - Now with more features!",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "vscode": "^1.100.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,17 @@ async function getContextData(document: vscode.TextDocument): Promise<any> {
     const workspaceSettings = await getWorkspaceSettings(workspaceFolder?.uri);
 
     const globalConfig = vscode.workspace.getConfiguration('jinjer');
-    const contextIncludeKey = globalConfig.get<string | null>('contextIncludeKey');
+    // const contextIncludeKey = globalConfig.get<string | null>('contextIncludeKey'); // Old way
+
+    // Determine effective contextIncludeKey: .jinjer-settings.json > VS Code settings > default
+    let effectiveContextIncludeKey: string | null | undefined;
+    if (workspaceSettings.hasOwnProperty('contextIncludeKey')) {
+        effectiveContextIncludeKey = workspaceSettings.contextIncludeKey;
+        console.log(`Jinjer: 🔑 Using contextIncludeKey from .jinjer-settings.json: "${effectiveContextIncludeKey}"`);
+    } else {
+        effectiveContextIncludeKey = globalConfig.get<string | null>('contextIncludeKey');
+        console.log(`Jinjer: 🔑 Using contextIncludeKey from VS Code settings (or default): "${effectiveContextIncludeKey}"`);
+    }
 
     // Determine contextFile: workspace setting > global setting > default
     const contextFileName = workspaceSettings.contextFile || globalConfig.get<string>('contextFile') || ".jinjer.json";
@@ -268,7 +278,7 @@ async function getContextData(document: vscode.TextDocument): Promise<any> {
     try {
         // Initialize processedPaths for the top-level call
         const processedPaths = new Set<string>();
-        contextData = await loadContextRecursive(contextFileUri, contextIncludeKey, processedPaths, workspaceFolder?.uri);
+        contextData = await loadContextRecursive(contextFileUri, effectiveContextIncludeKey, processedPaths, workspaceFolder?.uri);
         console.log("Jinjer: ✅ Successfully loaded and merged context data:", contextData);
     } catch (error) {
         vscode.window.showErrorMessage(`Error loading context data: ${error}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -507,6 +507,33 @@ async function loadContextRecursive(
                 console.log(`Jinjer: ↪️ Relative include path "${includePathString}" in "${contextPathKey}" resolved to "${resolvedIncludeUri.fsPath}"`);
             }
 
+            // <<< INSERT BOUNDARY CHECK HERE >>>
+            if (workspaceRoot) {
+                const normalizedWorkspacePath = path.normalize(workspaceRoot.fsPath);
+                const normalizedIncludePath = path.normalize(resolvedIncludeUri.fsPath);
+
+                // Ensure paths are compared in a way that handles trailing separators consistently,
+                // and considers the workspace path as a directory.
+                // A simple way is to ensure the workspace path ends with a separator for startsWith.
+                const workspacePathWithSep = normalizedWorkspacePath.endsWith(path.sep)
+                    ? normalizedWorkspacePath
+                    : normalizedWorkspacePath + path.sep;
+
+                // On Windows, paths can be case-insensitive. For robust check, convert both to lower case.
+                const isPathInsideWorkspace = process.platform === "win32"
+                    ? normalizedIncludePath.toLowerCase().startsWith(workspacePathWithSep.toLowerCase())
+                    : normalizedIncludePath.startsWith(workspacePathWithSep);
+
+                if (!isPathInsideWorkspace) {
+                    // Check if the include path is exactly the workspace path (e.g. including the root itself, though unlikely)
+                    // This case is fine as it's not "outside".
+                    const isPathExactlyWorkspace = normalizedIncludePath === normalizedWorkspacePath;
+                    if (!isPathExactlyWorkspace) {
+                         console.warn(`Jinjer: ⚠️ Included context file "${resolvedIncludeUri.fsPath}" is outside the current workspace ("${workspaceRoot.fsPath}"). Skipping.`);
+                         continue; // Skip this include
+                    }
+                }
+            }
 
             try {
                 // Check if the resolved file exists before attempting to load

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,6 +250,7 @@ async function getContextData(document: vscode.TextDocument): Promise<any> {
     const workspaceSettings = await getWorkspaceSettings(workspaceFolder?.uri);
 
     const globalConfig = vscode.workspace.getConfiguration('jinjer');
+    const contextIncludeKey = globalConfig.get<string | null>('contextIncludeKey');
 
     // Determine contextFile: workspace setting > global setting > default
     const contextFileName = workspaceSettings.contextFile || globalConfig.get<string>('contextFile') || ".jinjer.json";
@@ -259,28 +260,20 @@ async function getContextData(document: vscode.TextDocument): Promise<any> {
     const contextFileUri = await findContextFile(document.uri, contextFileName);
 
     if (!contextFileUri) {
-        console.error(`Jinjer: ❌ Context file "${contextFileName}" not found.`);
-        return {};  // Return empty object to avoid crashes
+        console.warn(`Jinjer: Context file "${contextFileName}" not found. No context will be loaded.`);
+        return {};  // Return empty object if no initial context file
     }
 
     let contextData = {};
     try {
-        const contextFile = await vscode.workspace.fs.readFile(contextFileUri);
-        const contextString = Buffer.from(contextFile).toString('utf8');
-
-        if (contextFileName.endsWith('.json')) {
-            contextData = JSON.parse(contextString);
-        } else if (contextFileName.endsWith('.yaml') || contextFileName.endsWith('.yml')) {
-            contextData = yaml.load(contextString) as any;
-        } else {
-            vscode.window.showWarningMessage('Unsupported context file format. Please use .json or .yaml');
-        }
-
-        console.log("Jinjer: ✅ Successfully loaded context data:", contextData);
-
+        // Initialize processedPaths for the top-level call
+        const processedPaths = new Set<string>();
+        contextData = await loadContextRecursive(contextFileUri, contextIncludeKey, processedPaths, workspaceFolder?.uri);
+        console.log("Jinjer: ✅ Successfully loaded and merged context data:", contextData);
     } catch (error) {
-        vscode.window.showErrorMessage(`Error reading context file: ${error}`);
-        console.error("Jinjer: ❌ Error loading context file:", error);
+        vscode.window.showErrorMessage(`Error loading context data: ${error}`);
+        console.error("Jinjer: ❌ Error loading context data:", error);
+        return {}; // Return empty on error
     }
 
     // Check and apply variable suffix
@@ -339,3 +332,209 @@ async function findContextFile(startUri: vscode.Uri, contextFileName: string): P
 }
 
 export function deactivate() {}
+
+// Helper function to parse context files (JSON or YAML)
+async function parseContextFile(fileUri: vscode.Uri): Promise<any> {
+    try {
+        const fileContent = await vscode.workspace.fs.readFile(fileUri);
+        const fileString = Buffer.from(fileContent).toString('utf8');
+        const fileExtension = path.extname(fileUri.fsPath).toLowerCase();
+
+        if (fileExtension === '.json') {
+            return JSON.parse(fileString);
+        } else if (fileExtension === '.yaml' || fileExtension === '.yml') {
+            return yaml.load(fileString) as any;
+        } else {
+            vscode.window.showWarningMessage(`Unsupported context file format for ${fileUri.fsPath}. Please use .json or .yaml.`);
+            return {};
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(`Error reading or parsing context file ${fileUri.fsPath}: ${error}`);
+        console.error(`Jinjer: ❌ Error reading or parsing context file ${fileUri.fsPath}:`, error);
+        return {}; // Return empty on error
+    }
+}
+
+// Properly implements deep merging for context objects.
+function deepMerge(target: any, source: any): any {
+    const output = { ...target }; // Shallow copy target to start
+
+    if (isObject(source)) {
+        Object.keys(source).forEach(key => {
+            if (isObject(source[key])) {
+                if (key in output && isObject(output[key])) {
+                    // If both target and source have an object for this key, recurse
+                    output[key] = deepMerge(output[key], source[key]);
+                } else {
+                    // If target does not have this key or it's not an object,
+                    // directly assign source's object (could be a deep clone if necessary,
+                    // but for context data, direct assignment is usually fine).
+                    // For simplicity and to match common expectations (like JSON.parse(JSON.stringify(obj))),
+                    // we'll create a new object for source[key] if we want to ensure no shared references
+                    // with the original source object, but typically this is not an issue for JSON-like data.
+                    // However, the recursive call handles deeper structures.
+                    output[key] = deepMerge({}, source[key]); // Ensure a new object if target didn't have one
+                }
+            } else {
+                // Primitives, arrays, or null from source overwrite whatever is in target
+                output[key] = source[key];
+            }
+        });
+    }
+    // If source is not an object (e.g. null, undefined, primitive),
+    // the original prompt implied source overwrites target.
+    // However, typical deepMerge implementations merge 'source' *into* 'target'.
+    // If source itself isn't an object, there's nothing to iterate and merge.
+    // The { ...target } handles the base case.
+    // If source is null or not an object, it shouldn't typically overwrite an existing target object.
+    // The definition of deepMerge implies merging object properties.
+    // Let's stick to merging properties if source is an object.
+    // If source is not an object, it should not alter target if target is an object.
+    // If target is also not an object, then source should be returned (as per step 1 of the prompt).
+    // This function assumes target is always an object due to its usage in loadContextRecursive.
+    // Let's refine based on the prompt's first rule:
+    // "If source is not an object or is null, return source (or target if source is undefined...)"
+    // This part is tricky if the function is meant to modify target in place or return a new object.
+    // The current structure returns a new object `output`.
+
+    // Let's re-evaluate the prompt's rules for the function signature `deepMerge(target: any, source: any): any`
+    // Rule 1: "If source is not an object or is null, return source..."
+    // This implies if source is primitive, it replaces target.
+    // This is not typical for a function named deepMerge that usually merges properties *into* a target object.
+    // Let's assume the primary goal is merging object properties deeply.
+    // The provided example: `deepMerge({ a: 1, b: { c: 2 } }, { b: { d: 3 }, e: 4 })`
+    // results in `{ a: 1, b: { c: 2, d: 3 }, e: 4 }`. This implies target is preserved and modified.
+
+    // Correcting based on standard deep merge behavior where target is modified or a new merged object is returned.
+    // The provided solution should modify `target` (or a copy) with `source`'s properties.
+
+    // Let's simplify and follow a common pattern:
+    // Create a new object from target.
+    // Iterate source. If source[key] is object and target[key] is object, recurse.
+    // Else, source[key] overwrites target[key].
+    // Arrays are overwritten, not merged.
+
+    // Revised logic for clarity and standard behavior:
+    if (!isObject(source)) {
+        // If source is not an object, standard deep merge doesn't apply in terms of merging properties.
+        // Depending on strict interpretation, if source is primitive, it could replace target if target is also primitive.
+        // However, in the context of merging JSON-like objects, this case is less common for the root call.
+        // For recursive calls, if source[key] is primitive, it will be handled by the else clause below.
+        // If the function is called with a non-object source at the top level, returning source is reasonable.
+        return source; // As per prompt's rule 1, if source is not an object.
+    }
+
+    // Ensure output is an object if target wasn't, but source is.
+    const result = isObject(target) ? { ...target } : {};
+
+    for (const key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+            const sourceValue = source[key];
+            const targetValue = result[key];
+            if (isObject(sourceValue) && isObject(targetValue)) {
+                // Both are objects, recurse
+                result[key] = deepMerge(targetValue, sourceValue);
+            } else {
+                // Not both objects (one might be, or neither), source overwrites
+                // This also handles array replacement as arrays are !isObject(true) for our helper,
+                // or if isObject includes arrays, this assignment is fine.
+                // Let's refine isObject to be specific for plain objects if array merging is different.
+                // Assuming isObject is for plain objects:
+                result[key] = sourceValue;
+            }
+        }
+    }
+    return result;
+}
+
+// Helper to check if a value is a plain object (and not an array or null)
+function isObject(item: any): boolean {
+    return (item && typeof item === 'object' && !Array.isArray(item) && item !== null);
+}
+
+async function loadContextRecursive(
+    contextFileUri: vscode.Uri,
+    contextIncludeKey: string | null | undefined,
+    processedPaths: Set<string>,
+    workspaceRoot?: vscode.Uri // Optional, for resolving absolute paths if ever needed
+): Promise<any> {
+    const contextPathKey = contextFileUri.fsPath;
+
+    // Check for circular dependencies
+    if (processedPaths.has(contextPathKey)) {
+        console.warn(`Jinjer: ⚠️ Circular dependency detected for context file: ${contextPathKey}. Skipping further processing for this path.`);
+        // Return empty or some indicator, or the data from this file without processing includes,
+        // to prevent infinite loop. For now, just parse and return this file's content.
+        return await parseContextFile(contextFileUri);
+    }
+
+    // Add current path to the set of processed paths for this recursion branch
+    processedPaths.add(contextPathKey);
+
+    let currentContext = await parseContextFile(contextFileUri);
+
+    if (!contextIncludeKey || typeof currentContext !== 'object' || currentContext === null) {
+        // No key to look for, or currentContext is not an object, so no includes possible
+        processedPaths.delete(contextPathKey); // Remove before returning
+        return currentContext;
+    }
+
+    const includePaths = currentContext[contextIncludeKey];
+
+    if (Array.isArray(includePaths)) {
+        // Remove the include key from the current context to avoid it being in the final merged data
+        // unless it's explicitly part of another included file.
+        // Alternatively, ensure deepMerge handles this or it's filtered out at the end.
+        // For now, let's leave it and assume deepMerge overwrites it if necessary.
+        // delete currentContext[contextIncludeKey]; // Optional: consider if the key itself should be removed
+
+        for (const includePathString of includePaths) {
+            if (typeof includePathString !== 'string') {
+                console.warn(`Jinjer: ⚠️ Invalid include path found in ${contextPathKey}: ${includePathString}. Must be a string. Skipping.`);
+                continue;
+            }
+
+            let resolvedIncludeUri: vscode.Uri;
+            if (path.isAbsolute(includePathString)) {
+                // True absolute path, use it directly.
+                resolvedIncludeUri = vscode.Uri.file(includePathString);
+                console.log(`Jinjer: ➡️ Absolute include path "${includePathString}" resolved to "${resolvedIncludeUri.fsPath}"`);
+            } else {
+                // Relative paths are relative to the directory of the current context file.
+                // contextPathKey is contextFileUri.fsPath.
+                const currentContextDir = vscode.Uri.file(path.dirname(contextPathKey));
+                resolvedIncludeUri = vscode.Uri.joinPath(currentContextDir, includePathString);
+                console.log(`Jinjer: ↪️ Relative include path "${includePathString}" in "${contextPathKey}" resolved to "${resolvedIncludeUri.fsPath}"`);
+            }
+
+
+            try {
+                // Check if the resolved file exists before attempting to load
+                // Note: parseContextFile will handle file not found, but good to log here too.
+                await vscode.workspace.fs.stat(resolvedIncludeUri); // This will throw if file doesn't exist
+
+                const includedContext = await loadContextRecursive(
+                    resolvedIncludeUri,
+                    contextIncludeKey,
+                    processedPaths, // Pass the same set to track dependencies across the entire load operation
+                    workspaceRoot
+                );
+                currentContext = deepMerge(currentContext, includedContext);
+            } catch (error) {
+                 if (error instanceof vscode.FileSystemError && error.code === 'FileNotFound') {
+                    console.warn(`Jinjer: ⚠️ Included context file not found: ${resolvedIncludeUri.fsPath}. Skipping.`);
+                } else {
+                    console.error(`Jinjer: ❌ Error processing included context file ${resolvedIncludeUri.fsPath}:`, error);
+                    // Decide if you want to bubble the error or just skip this include
+                }
+            }
+        }
+    } else if (includePaths !== undefined) {
+        // The key exists but is not an array
+        console.warn(`Jinjer: ⚠️ The value of '${contextIncludeKey}' in ${contextPathKey} must be an array of strings. Found:`, includePaths);
+    }
+
+    // Remove current path from the set before returning up the recursion stack
+    processedPaths.delete(contextPathKey);
+    return currentContext;
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -742,8 +742,6 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
 });
 
-});
-
 // --- Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---
 suite('Context Inclusion Tests (New)', () => {
     let testSuiteStubs: sinon.SinonStub[] = [];
@@ -1213,7 +1211,7 @@ suite('Context Inclusion Tests (New)', () => {
         mockFileContents.set(absoluteOutsidePath, JSON.stringify(outsideContent));
 
         const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
-            if (p === absoluteOutsidePath) return true;
+            if (p === absoluteOutsidePath) {return true;}
             return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
         });
         testSuiteStubs.push(pathIsAbsoluteStub);
@@ -1245,7 +1243,7 @@ suite('Context Inclusion Tests (New)', () => {
         mockFileContents.set(absoluteInsidePath, JSON.stringify(insideContent));
 
         const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
-            if (p === absoluteInsidePath) return true;
+            if (p === absoluteInsidePath) {return true;}
             return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
         });
         testSuiteStubs.push(pathIsAbsoluteStub);
@@ -1266,7 +1264,7 @@ suite('Context Inclusion Tests (New)', () => {
 
     test('Should load absolute include when no workspace is open', async () => {
         // Simulate no workspace being open
-        const getWorkspaceFolderStubInstance = testSuiteStubs.find(s => s.stub && s.stub.name === 'getWorkspaceFolder'); // Assuming stubs are named or identifiable
+        const getWorkspaceFolderStubInstance = testSuiteStubs.find(s => s.name === 'getWorkspaceFolder'); // Assuming stubs are named or identifiable
         if (getWorkspaceFolderStubInstance && (getWorkspaceFolderStubInstance as sinon.SinonStub).name === 'getWorkspaceFolder') { // Check if it's the correct stub
             (getWorkspaceFolderStubInstance as sinon.SinonStub).returns(undefined);
         } else {
@@ -1302,7 +1300,7 @@ suite('Context Inclusion Tests (New)', () => {
         mockFileContents.set(absoluteIncludePath, JSON.stringify(includeContent));
 
         const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
-            if (p === absoluteIncludePath) return true;
+            if (p === absoluteIncludePath) {return true;}
             return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
         });
         testSuiteStubs.push(pathIsAbsoluteStub);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -649,141 +649,191 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
 });
 
-// --- Suite for Context Inclusion Tests ---
-suite('Context Inclusion Tests', () => {
-    // REMOVED: let mockFileContents: Map<string, string>;
-    // We will use mockFileContents from the outer suite scope.
-    let mockWorkspaceFolder: vscode.WorkspaceFolder; // This is fine, it's specific to this suite's setup.
-    const testFixtureRoot = path.resolve(__dirname, 'testFixture', 'contextIncludes'); // Adjusted path
+});
 
-    // Helper to get the URI for a test fixture file
+// --- Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---
+suite('Context Inclusion Tests (New)', () => {
+    let testSuiteStubs: sinon.SinonStub[] = [];
+    let testSuiteSpies: sinon.SinonSpy[] = [];
+    const mockFileContents = new Map<string, string>();
+    const mockJinjerConfig: { [key: string]: any } = {};
+    let mockWorkspaceFolder: vscode.WorkspaceFolder;
+    const testFixtureRoot = path.resolve(__dirname, 'testFixture', 'contextIncludes');
     const getFixtureUri = (fileName: string) => vscode.Uri.file(path.join(testFixtureRoot, fileName));
+    let activeTextEditorStub: sinon.SinonStub | undefined = undefined;
 
-    // This will hold the original getConfiguration stub if we were to capture it,
-    // but since we are REMOVING the inner stub, this might not be needed here.
-    // let originalGetConfiguration: sinon.SinonStub | undefined;
+    // Spies that will be initialized in beforeEach and used by tests
+    let renderStringSpy: sinon.SinonSpy;
+    let consoleWarnSpy: sinon.SinonSpy;
+    let nunjucksConfigureSpy: sinon.SinonSpy;
 
-    setup(async () => {
-        // mockFileContents is from the outer scope. It will be cleared in beforeEach.
-        mockWorkspaceFolder = { // This mockWorkspaceFolder is specific to this suite's tests
+    beforeEach(async () => {
+        mockFileContents.clear();
+        Object.keys(mockJinjerConfig).forEach(key => delete mockJinjerConfig[key]);
+        // Set default configurations for this suite
+        mockJinjerConfig.contextIncludeKey = '_jinjer_include_contexts';
+        mockJinjerConfig.contextFile = 'context.json'; // Default for most tests
+        mockJinjerConfig.variableSuffix = '';
+
+        mockWorkspaceFolder = {
             uri: vscode.Uri.file(testFixtureRoot),
             name: 'ContextIncludesTestWorkspace',
             index: 0
         };
 
-        // Ensure the getConfiguration stub from the outer suite is available
-        // This is a bit tricky due to nested suites. We might need to re-stub or ensure it's broadly scoped.
-        // For simplicity, let's assume the outer suite's stubs are active or re-apply similar logic.
+        // Stub vscode.workspace.getConfiguration
+        const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section) => {
+            if (section === 'jinjer') {
+                return {
+                    get: (key: string) => mockJinjerConfig[key],
+                    has: (key: string) => key in mockJinjerConfig,
+                    inspect: (key: string) => ({ key: `jinjer.${key}`, globalValue: mockJinjerConfig[key], defaultValue: undefined, workspaceValue: undefined, globalLanguageValue: undefined, workspaceFolderValue: undefined, workspaceFolderLanguageValue: undefined, languageIds: undefined}),
+                    update: sinon.stub().callsFake(async (key:string, value:any) => { mockJinjerConfig[key] = value; return Promise.resolve(); }) // Basic stub for update
+                };
+            }
+            // IMPORTANT: For non-'jinjer' sections, call the original function if possible,
+            // or return a generic stub. This prevents breaking other parts of VS Code a test might touch.
+            // However, in a focused unit test, you might only care about your section.
+            // For this self-contained suite, we might need to ensure other configurations are not touched
+            // or are handled by a broader mechanism if tests interact with them.
+            // Returning a generic stub for non-jinjer sections:
+            return {
+                get: sinon.stub().returns(undefined),
+                has: sinon.stub().returns(false),
+                inspect: sinon.stub().returns(undefined),
+                update: sinon.stub().resolves()
+            } as any;
+        });
+        testSuiteStubs.push(getConfigurationStub);
 
-        // Override vscode.workspace.fs.readFile and vscode.workspace.fs.stat for our test files
-        // These stubs are pushed to the global `stubs` array by the outer suite's setup.
-        // We need to ensure they are aware of our new mockFileContents map.
-        // The best approach is to ensure the stubs created in the outer suite's setup
-        // use the `mockFileContents` and `mockWorkspaceFolder` that we can update here.
-        // This requires `mockFileContents` and `mockWorkspaceFolder` to be declared at a scope accessible
-        // to the `readFile` and `stat` stubs. Let's assume they are, or adjust.
-        // For this example, I'll re-define the stubs for fs operations to be self-contained for this suite
-        // if necessary, or rely on careful ordering and cleanup.
+        // Stub vscode.workspace.fs.readFile
+        const readFileStub = sinon.stub(vscode.workspace.fs, 'readFile').callsFake(async (uri: vscode.Uri) => {
+            const filePath = uri.fsPath;
+            if (mockFileContents.has(filePath)) {
+                return Buffer.from(mockFileContents.get(filePath)!);
+            }
+            throw vscode.FileSystemError.FileNotFound(uri);
+        });
+        testSuiteStubs.push(readFileStub);
 
-        // The existing stubs for fs.readFile and fs.stat should be fine if they use a shared, updatable mockFileContents.
-        // Let's ensure our local mockFileContents is used by those stubs.
-        // This might involve directly manipulating the map used by the outer stubs, or re-stubbing.
-        // For now, let's assume we can populate the `mockFileContents` map that the existing stubs use.
-        // This requires `mockFileContents` from the outer scope to be assigned here.
-        // This is problematic with strict `let` scoping in `setup`.
-        // A better way: the outer suite's `mockFileContents` should be cleared and re-populated here.
-        // Or, `setupAndPreview` needs to be adapted, or we create a new `getTestData` that sets up its own mocks for fs.
+        // Stub vscode.workspace.fs.stat
+        const statStub = sinon.stub(vscode.workspace.fs, 'stat').callsFake(async (uri: vscode.Uri) => {
+            const filePath = uri.fsPath;
+            // Check if it's the specific workspace folder URI for directory type
+            if (filePath === mockWorkspaceFolder.uri.fsPath) {
+                return {
+                    type: vscode.FileType.Directory,
+                    size: 0,
+                    mtime: Date.now(),
+                    ctime: Date.now()
+                } as vscode.FileStat;
+            }
+            // Check if it's a file in our mock file system
+            if (mockFileContents.has(filePath)) {
+                return {
+                    type: vscode.FileType.File,
+                    size: mockFileContents.get(filePath)?.length || 0,
+                    mtime: Date.now(),
+                    ctime: Date.now()
+                } as vscode.FileStat;
+            }
+            // For any other path, including subdirectories that are not explicitly defined,
+            // throw FileNotFound unless we add more sophisticated directory mocking.
+            // For context inclusion, we mostly care about specific files existing.
+            // If a directory needs to exist for path.dirname to work, stat might be called on it.
+            // For simplicity, let's assume only files or the root workspace folder are stat-ed.
+            // If a test needs a directory to exist, it should be mocked in mockFileContents with a special value,
+            // or this stub needs to be smarter. For now, this is typical for file-based ops.
+            throw vscode.FileSystemError.FileNotFound(uri);
+        });
+        testSuiteStubs.push(statStub);
 
-        // REMOVED: Stubbing of vscode.workspace.getConfiguration from inner suite's setup.
-        // The tests in this suite will rely on the getConfiguration stub from the outer suite,
-        // and will modify the shared mockGlobalConfig in beforeEach or directly in tests.
+        // Stub vscode.workspace.getWorkspaceFolder
+        const getWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(mockWorkspaceFolder);
+        testSuiteStubs.push(getWorkspaceFolderStub);
 
-        // The following stubs for activeTextEditor and getWorkspaceFolder are also potentially
-        // redundant if the outer suite's setup is sufficient and mockWorkspaceFolder is
-        // updated correctly for this suite's context.
-        // For now, these are kept as they might be providing suite-specific behavior for these elements.
-        // However, they also push to the global `stubs` array.
-
-        // Populate mockFileContents with actual files from the testFixture directory
-        // This is crucial. The tests will rely on `fs.readFile` stub to provide these.
-        // We need a way to tell the `fs.readFile` stub about these files.
-        // The simplest is to load them into the globally defined `mockFileContents` from the outer suite.
-        // This is a bit of a hack due to test structure.
-        // A cleaner way would be for the `fs.readFile` stub itself to actually read from disk for test fixtures.
-        // For now, let's assume we'll manually populate `mockFileContents` in each test for the files it needs.
-        // Or, even better, make `getTestData` set up the `mockFileContents` for the specific context files.
-
-        // Reset active document for `getContextData` which relies on `vscode.window.activeTextEditor`
-        // The `getContextData` function itself doesn't use the content of the activeTextEditor,
-        // only its URI to find the workspace and search for context files.
-        const dummyDocUri = vscode.Uri.joinPath(mockWorkspaceFolder.uri, 'dummy_template.j2');
+        // Stub vscode.window.activeTextEditor
+        const dummyDocUri = vscode.Uri.joinPath(mockWorkspaceFolder.uri, 'dummy_template_new.j2');
         const mockEditor = {
             document: { uri: dummyDocUri, fileName: dummyDocUri.fsPath, getText: () => "" }
         };
-        // Ensure existing stub is restored before creating a new one or use .returns() to change behavior
-        let activeTextEditorStub = stubs.find(s => s && s.name === 'activeTextEditorStub' && (s as any).stub);
-        if (activeTextEditorStub) {
-            (activeTextEditorStub as sinon.SinonStub).returns(mockEditor);
-        } else {
-            stubs.push(sinon.stub(vscode.window, 'activeTextEditor').named('activeTextEditorStub').returns(mockEditor));
+        if (activeTextEditorStub && typeof activeTextEditorStub.restore === 'function') {
+            activeTextEditorStub.restore(); // Restore if it was stubbed in a previous test run by this suite
         }
-        stubs.push(sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(mockWorkspaceFolder));
+        activeTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').returns(mockEditor as any);
+        testSuiteStubs.push(activeTextEditorStub);
 
-    });
+        // Stub vscode.window.createWebviewPanel
+        // Using the global mockWebviewPanel defined at the top of the file.
+        const createWebviewPanelStub = sinon.stub(vscode.window, 'createWebviewPanel').returns(mockWebviewPanel as any);
+        testSuiteStubs.push(createWebviewPanelStub);
 
-    teardown(async () => {
-        // The stubs pushed by this suite's setup (if any remain) and by individual tests
-        // (e.g. path.isAbsolute stub, console.warn spy) are added to the global `stubs` and `spies`
-        // arrays, which are cleaned by the outer suite's teardown. So, no specific teardown
-        // for stubs is needed here if that system works as intended.
+        // Stub console.warn
+        consoleWarnSpy = sinon.spy(console, 'warn'); // Assign to suite-level variable
+        testSuiteSpies.push(consoleWarnSpy);
 
-        // Clean up global config updates specifically made by this suite's tests/beforeEach
-        await vscode.workspace.getConfiguration('jinjer').update('contextIncludeKey', undefined, vscode.ConfigurationTarget.Global);
-        await vscode.workspace.getConfiguration('jinjer').update('contextFile', undefined, vscode.ConfigurationTarget.Global);
-    });
+        // Spy on nunjucks.Environment.prototype.renderString
+        renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString'); // Assign to suite-level variable
+        testSuiteSpies.push(renderStringSpy);
 
-    /**
-     * Helper function to simulate file system for context loading tests.
-     * It populates the mockFileContents map which is used by the fs.readFile stub.
-     * It then calls the actual getContextData function (assuming it's exported).
-     * @param mainDocumentName The name of the "template" file, used to determine search start.
-     * @param contextFileName The name of the context file to search for.
-     * @param filesToMock A map where keys are file names (relative to testFixtureRoot) and values are their content.
-     */
-    // `mockFileContents` and `mockGlobalConfig` are from the outer suite.
-    // `setupAndPreview` is also from the outer suite.
-    // `spies` array is from the outer suite for centralized cleanup.
+        // Spy on nunjucks.configure
+        nunjucksConfigureSpy = sinon.spy(nunjucks, 'configure'); // Assign to suite-level variable
+        testSuiteSpies.push(nunjucksConfigureSpy);
 
-    beforeEach(() => {
-        // Clear the mockFileContents (from outer scope)
-        if (mockFileContents && typeof mockFileContents.clear === 'function') {
-            mockFileContents.clear();
-        } else {
-            // This case should ideally not happen if mockFileContents is correctly from the outer scope.
-            console.warn("Context Inclusion Tests beforeEach: mockFileContents not found or not a Map.");
-        }
-
-        // Reset relevant parts of the outer mockGlobalConfig for this suite's defaults
-        if (mockGlobalConfig) {
-            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]); // Clear properties first
-            mockGlobalConfig.contextIncludeKey = '_jinjer_include_contexts';
-            mockGlobalConfig.contextFile = 'context.json'; // Default for most tests in this suite
-            mockGlobalConfig.variableSuffix = ''; // No suffix by default for this suite
-        } else {
-            // This case should ideally not happen.
-            console.warn("Context Inclusion Tests beforeEach: mockGlobalConfig not found.");
+        // Activate the extension
+        const mockMemento = new MockMemento(); // Using the class defined at the top
+        const mockContext: vscode.ExtensionContext = {
+            subscriptions: [], workspaceState: mockMemento, globalState: mockMemento,
+            extensionPath: '/fake/path_new_suite', storagePath: '/fake/storage_new', logPath: '/fake/log_new', extensionUri: vscode.Uri.file('/fake_new_suite'),
+            environmentVariableCollection: new MockEnvironmentVariableCollection(), extensionMode: vscode.ExtensionMode.Test,
+            globalStorageUri: vscode.Uri.file('/fake_new_suite/globalStorage'), logUri: vscode.Uri.file('/fake_new_suite/logUri'), storageUri: vscode.Uri.file('/fake_new_suite/storageUri'),
+            asAbsolutePath: (p) => path.resolve('/fake_new_suite',p), secrets: new MockSecretStorage(),
+            globalStoragePath: '/fake_new_suite/globalStoragePath',
+            extension: { id: 'test.jinjer.new', extensionPath: '/fake_new_suite', isActive: false, packageJSON: {name: "jinjer-test", version: "0.0.0"}, activate: (() => ({})) as any, exports: {}, extensionKind: vscode.ExtensionKind.Workspace } as any,
+            languageModelAccessInformation: new MockLanguageModelAccessInformation()
+        };
+        // Ensure extensionActivate is available. It's imported at the top of the file.
+        if (extensionActivate) {
+            await extensionActivate(mockContext);
         }
     });
+
+    afterEach(async () => {
+        testSuiteStubs.forEach(s => s.restore());
+        testSuiteStubs = [];
+        testSuiteSpies.forEach(s => s.restore());
+        testSuiteSpies = [];
+
+        // activeTextEditorStub is already in testSuiteStubs, so it's restored there.
+        activeTextEditorStub = undefined;
+
+        if (extensionDeactivate) {
+            extensionDeactivate();
+        }
+        // Spies on prototypes or global objects need explicit restoration if not in testSuiteSpies
+        // or if the spy wrapper itself isn't what's stored.
+        // Nunjucks spies are on prototypes, console.warn is global.
+        // The `sinon.spy` calls above replace the method with a spy. Restoring them:
+        if ((nunjucks.Environment.prototype.renderString as sinon.SinonSpy).restore) {
+            (nunjucks.Environment.prototype.renderString as sinon.SinonSpy).restore();
+        }
+        if ((nunjucks.configure as sinon.SinonSpy).restore) {
+            (nunjucks.configure as sinon.SinonSpy).restore();
+        }
+        if ((console.warn as sinon.SinonSpy).restore) {
+            (console.warn as sinon.SinonSpy).restore();
+        }
+    });
+
+    // Placeholder test removed, actual tests will be inserted below by copying from the old suite and adapting.
 
     test('No Include Key', async () => {
-        mockGlobalConfig['contextFile'] = 'main_no_include.json';
+        mockJinjerConfig.contextFile = 'main_no_include.json';
         const mainContent = { val: "main_no_include_val" };
         mockFileContents.set(getFixtureUri('main_no_include.json').fsPath, JSON.stringify(mainContent));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ val }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -791,14 +841,12 @@ suite('Context Inclusion Tests', () => {
     });
 
     test('Empty Include List', async () => {
-        mockGlobalConfig['contextFile'] = 'main_empty_include.json';
+        mockJinjerConfig.contextFile = 'main_empty_include.json';
         const mainContent = { val: "main_empty_include_val", "_jinjer_include_contexts": [] };
         mockFileContents.set(getFixtureUri('main_empty_include.json').fsPath, JSON.stringify(mainContent));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ val }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -806,21 +854,16 @@ suite('Context Inclusion Tests', () => {
     });
 
     test('Single Include', async () => {
-        mockGlobalConfig['contextFile'] = 'main_single_include.json'; // Set the main context file for the test
+        mockJinjerConfig.contextFile = 'main_single_include.json';
 
         const mainContent = { "mainVal": "m_single", "_jinjer_include_contexts": ["include1.json"] };
         const include1Content = { "inclVal": "i1_single" };
 
-        // Populate the mock file system
         mockFileContents.set(getFixtureUri('main_single_include.json').fsPath, JSON.stringify(mainContent));
         mockFileContents.set(getFixtureUri('include1.json').fsPath, JSON.stringify(include1Content));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy); // Add to global spies list for cleanup
-
-        // Trigger the preview. The active document URI helps locate the context file.
-        // The content of dummy.j2 doesn't matter, only its path for context resolution.
-        await setupAndPreview('{{ mainVal }} {{ inclVal }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsedByNunjucks = renderStringSpy.lastCall.args[1];
@@ -828,13 +871,13 @@ suite('Context Inclusion Tests', () => {
         const expectedContext = {
             "mainVal": "m_single",
             "inclVal": "i1_single",
-            "_jinjer_include_contexts": ["include1.json"] // The include key itself remains
+            "_jinjer_include_contexts": ["include1.json"]
         };
         assert.deepStrictEqual(contextUsedByNunjucks, expectedContext);
     });
 
     test('Nested Include (Multi-Level)', async () => {
-        mockGlobalConfig['contextFile'] = 'main_multi_level.json';
+        mockJinjerConfig.contextFile = 'main_multi_level.json';
 
         const mainContent = { "mainVal": "m_multi", "_jinjer_include_contexts": ["level1.json"] };
         const level1Content = { "l1Val": "l1_multi", "_jinjer_include_contexts": ["level2.json"] };
@@ -844,10 +887,8 @@ suite('Context Inclusion Tests', () => {
         mockFileContents.set(getFixtureUri('level1.json').fsPath, JSON.stringify(level1Content));
         mockFileContents.set(getFixtureUri('level2.json').fsPath, JSON.stringify(level2Content));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ mainVal }} {{ l1Val }} {{ l2Val }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -856,15 +897,13 @@ suite('Context Inclusion Tests', () => {
             "mainVal": "m_multi",
             "l1Val": "l1_multi",
             "l2Val": "l2_multi",
-            "_jinjer_include_contexts": ["level2.json"] // from level1.json, as it's merged last at that level
+            "_jinjer_include_contexts": ["level2.json"]
         };
-        // The _jinjer_include_contexts from main.json is overwritten by level1.json's during merge.
-        // And level2.json has no include key, so level1's remains.
         assert.deepStrictEqual(contextUsed, expectedContext);
     });
 
     test('Merge Conflict (Last Include Wins for conflicting keys)', async () => {
-        mockGlobalConfig['contextFile'] = 'main_conflict.json';
+        mockJinjerConfig.contextFile = 'main_conflict.json';
 
         const mainContent = { "key": "main_val", "mainOnlyKey": "main_only_val", "_jinjer_include_contexts": ["conflict_source.json"] };
         const conflictContent = { "key": "conflict_val", "conflictOnlyKey": "conflict_only_val" };
@@ -872,16 +911,14 @@ suite('Context Inclusion Tests', () => {
         mockFileContents.set(getFixtureUri('main_conflict.json').fsPath, JSON.stringify(mainContent));
         mockFileContents.set(getFixtureUri('conflict_source.json').fsPath, JSON.stringify(conflictContent));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ key }} {{ mainOnlyKey }} {{ conflictOnlyKey }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
 
         const expectedContext = {
-            "key": "conflict_val", // Value from conflict_source.json should overwrite main.json
+            "key": "conflict_val",
             "mainOnlyKey": "main_only_val",
             "conflictOnlyKey": "conflict_only_val",
             "_jinjer_include_contexts": ["conflict_source.json"]
@@ -890,26 +927,29 @@ suite('Context Inclusion Tests', () => {
     });
 
     test('Relative Path Navigation(../common.json)', async () => {
-        // The context file to be found is 'base/main_relative_up.json'
-        // So, the "active document" for context searching needs to be conceptually in the 'base' subdir
-        // or the contextFile path needs to be 'base/main_relative_up.json'.
-        // Let's make the active document in 'base' so findContextFile starts searching from there.
-        mockGlobalConfig['contextFile'] = 'main_relative_up.json'; // This file will be searched for starting from dummy_in_base.j2's dir.
+        mockJinjerConfig.contextFile = 'main_relative_up.json';
 
         const mainContent = { "mainVal": "main_relative_up_val", "_jinjer_include_contexts": ["../common_data.json"] };
         const commonDataContent = { "commonVal": "common_data_val" };
 
-        // main_relative_up.json is in base/
         mockFileContents.set(getFixtureUri('base/main_relative_up.json').fsPath, JSON.stringify(mainContent));
-        // common_data.json is in the parent of base/ (which is testFixtureRoot)
         mockFileContents.set(getFixtureUri('common_data.json').fsPath, JSON.stringify(commonDataContent));
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
+        // For this test, the "active document" needs to be in the 'base' subdirectory
+        // so that 'main_relative_up.json' is found correctly by findContextFile.
+        // The beforeEach already sets up activeTextEditor with 'dummy_template_new.j2' at the testFixtureRoot.
+        // We need to override it for this test.
+        if (activeTextEditorStub && typeof activeTextEditorStub.restore === 'function') {
+            activeTextEditorStub.restore(); // remove the default one from beforeEach
+        }
+        const dummyInBaseDocUri = getFixtureUri('base/dummy_in_base.j2');
+        activeTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').returns({
+            document: { uri: dummyInBaseDocUri, fileName: dummyInBaseDocUri.fsPath, getText: () => "" }
+        } as any);
+        testSuiteStubs.push(activeTextEditorStub); // Add for cleanup by suite's afterEach
 
-        // The dummy template is effectively at 'testFixtureRoot/base/dummy_in_base.j2'
-        // This ensures getContextData starts searching for 'main_relative_up.json' from the 'base' directory.
-        await setupAndPreview('{{ mainVal }} {{ commonVal }}', 'base/dummy_in_base.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -923,22 +963,16 @@ suite('Context Inclusion Tests', () => {
     });
 
     test('Relative Path Include (./subdir/file.json)', async () => {
-        mockGlobalConfig['contextFile'] = 'main_relative_path.json';
+        mockJinjerConfig.contextFile = 'main_relative_path.json';
 
         const mainContent = { "mainVal": "main_relative_val", "_jinjer_include_contexts": ["./subdir/relative.json"] };
         const relativeContent = { "relativeVal": "relative_subdir_val" };
 
         mockFileContents.set(getFixtureUri('main_relative_path.json').fsPath, JSON.stringify(mainContent));
-        // The path for relative.json should be testFixtureRoot + '/subdir/relative.json'
         mockFileContents.set(getFixtureUri('subdir/relative.json').fsPath, JSON.stringify(relativeContent));
 
-
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        // The main_relative_path.json is at the root of testFixtureRoot for context searching.
-        // The include path ./subdir/relative.json will be resolved from testFixtureRoot.
-        await setupAndPreview('{{ mainVal }} {{ relativeVal }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -952,7 +986,7 @@ suite('Context Inclusion Tests', () => {
     });
 
     test('Circular Dependency', async () => {
-        mockGlobalConfig['contextFile'] = 'main_circular_a.json';
+        mockJinjerConfig.contextFile = 'main_circular_a.json';
 
         const circAContent = { "val_a": "a", "shared_key": "from_a", "_jinjer_include_contexts": ["main_circular_b.json"] };
         const circBContent = { "val_b": "b", "shared_key": "from_b", "_jinjer_include_contexts": ["main_circular_a.json"] };
@@ -960,167 +994,78 @@ suite('Context Inclusion Tests', () => {
         mockFileContents.set(getFixtureUri('main_circular_a.json').fsPath, JSON.stringify(circAContent));
         mockFileContents.set(getFixtureUri('main_circular_b.json').fsPath, JSON.stringify(circBContent));
 
-        // Spy on console.warn for circular dependency message
-        const consoleWarnSpy = sinon.spy(console, 'warn');
-        spies.push(consoleWarnSpy);
-
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ val_a }} {{ val_b }} {{ shared_key }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
 
-        // Expected: main_circular_a is loaded first. It tries to load main_circular_b.
-        // main_circular_b is loaded. It tries to load main_circular_a.
-        // main_circular_a is detected in processedPaths, so its content (as parsed initially) is returned to b.
-        // Then b's content (now merged with a's original) is returned to a.
-        // So, b's version of shared_key should win as it's merged into a.
         const expectedContext = {
             "val_a": "a",
             "val_b": "b",
-            "shared_key": "from_a", // main_circular_a loads main_circular_b. main_circular_b's content is merged into main_circular_a.
-                                  // When main_circular_b tries to load main_circular_a again, it gets main_circular_a's content *without* a second merge of B.
-                                  // So, the content of A (which has its include key) is merged with B.
-                                  // A is target, B is source. B's shared_key overwrites A's.
-                                  // Wait, the deepMerge is (target, source).
-                                  // 1. Load A: {val_a, shared_key:from_a, _inc: [B]}
-                                  // 2. Process include B:
-                                  //    Load B: {val_b, shared_key:from_b, _inc: [A]}
-                                  //    Process include A for B: A is in processedPaths. Parse A: {val_a, shared_key:from_a, _inc: [B]}. This is `includedContext` for B.
-                                  //    Merge (B, A_parsed_raw): B = {...B, ...A_parsed_raw}. So B.shared_key becomes "from_a". B._inc becomes [B] from A.
-                                  //    Context from B's recursion: {val_b:"b", val_a:"a", shared_key:"from_a", _inc:[B]}
-                                  // 3. Merge B_processed into A: A = {...A, ...B_processed}
-                                  //    A.shared_key was "from_a", B_processed.shared_key is "from_a". So it's "from_a".
-                                  //    A._inc was [B], B_processed._inc is [B]. So it's [B].
-                                  // This implies shared_key should be "from_a".
-                                  // Let's trace again:
-                                  // loadRecursive(A, key, processed={}):
-                                  //  processed.add(A_path)
-                                  //  currentContextA = parse(A) = { val_a:"a", shared_key:"from_a", _inc:[B] }
-                                  //  loop include "B":
-                                  //   resolvedB = path_B
-                                  //   includedContextB = loadRecursive(B, key, processed={A_path}):
-                                  //    processed.add(B_path) -> processed={A_path, B_path}
-                                  //    currentContextB = parse(B) = { val_b:"b", shared_key:"from_b", _inc:[A] }
-                                  //    loop include "A":
-                                  //     resolvedA = path_A
-                                  //     A_path is in processedPaths. WARN circular.
-                                  //     return parse(A) = { val_a:"a", shared_key:"from_a", _inc:[B] } -> this is innerIncludedContextA
-                                  //    currentContextB = deepMerge(currentContextB, innerIncludedContextA)
-                                  //                = deepMerge({val_b:"b",shared_key:"from_b",_inc:[A]}, {val_a:"a",shared_key:"from_a",_inc:[B]})
-                                  //                = {val_b:"b", val_a:"a", shared_key:"from_a", _inc:[B]}
-                                  //    processed.delete(B_path)
-                                  //    return currentContextB -> this is includedContextB for A's load.
-                                  //  currentContextA = deepMerge(currentContextA, includedContextB)
-                                  //              = deepMerge({val_a:"a",shared_key:"from_a",_inc:[B]}, {val_b:"b",val_a:"a",shared_key:"from_a",_inc:[B]})
-                                  //              = {val_a:"a", val_b:"b", shared_key:"from_a", _inc:[B]}
-                                  //  processed.delete(A_path)
-                                  //  return currentContextA
-
-            "_jinjer_include_contexts": ["main_circular_a.json"] // From main_circular_b.json, as it's merged last into A (and its include of A is skipped)
-                                                              // No, from the trace above, it should be _inc:[B] from A, which was itself from B's include of A, then merged.
-                                                              // The final A is merged with (B merged with raw A).
-                                                              // So A's original _inc:[B] is merged with B's _inc:[B] (which came from raw A). Result: _inc:[B]
+            "shared_key": "from_a",
+            "_jinjer_include_contexts": ["main_circular_b.json"]
         };
-         assert.deepStrictEqual(contextUsed, {
-            "val_a": "a",
-            "val_b": "b",
-            "shared_key": "from_a", // Correct from the detailed trace.
-            "_jinjer_include_contexts": ["main_circular_b.json"] // Corrected based on detailed trace.
-        });
-
-
-        // Check that a warning for circular dependency was logged
+        assert.deepStrictEqual(contextUsed, expectedContext);
         assert.ok(consoleWarnSpy.calledWith(sinon.match(/Circular dependency detected/)), 'Expected console.warn for circular dependency');
     });
 
     test('Non-existent Include', async () => {
-        mockGlobalConfig['contextFile'] = 'main_non_existent_include.json';
+        mockJinjerConfig.contextFile = 'main_non_existent_include.json';
 
         const mainContent = { "mainVal": "main_val", "_jinjer_include_contexts": ["non_existent.json"] };
-        // non_existent.json is NOT added to mockFileContents
-
         mockFileContents.set(getFixtureUri('main_non_existent_include.json').fsPath, JSON.stringify(mainContent));
 
-        const consoleWarnSpy = sinon.spy(console, 'warn');
-        spies.push(consoleWarnSpy);
-
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ mainVal }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
 
-        // Expected: mainContent is loaded, the include of non_existent.json is skipped.
         assert.deepStrictEqual(contextUsed, mainContent);
-
-        // Check that a warning for the missing file was logged
         assert.ok(consoleWarnSpy.calledWith(sinon.match(/Included context file not found/)), 'Expected console.warn for missing include file');
         assert.ok(consoleWarnSpy.calledWith(sinon.match(/non_existent.json/)), 'Expected non_existent.json to be mentioned in the warning');
     });
 
     test('Include YAML from JSON', async () => {
-        mockGlobalConfig['contextFile'] = 'main_include_yaml.json';
+        mockJinjerConfig.contextFile = 'main_include_yaml.json';
 
         const mainContent = { "mainJsonVal": "main_json_val", "_jinjer_include_contexts": ["data.yaml"] };
-        const yamlContentString = `yamlVal: "yaml_val"\notherYamlKey: "other_yaml_key_val"`; // Raw YAML string
+        const yamlContentString = `yamlVal: "yaml_val"\notherYamlKey: "other_yaml_key_val"`;
         const expectedYamlParsed = { yamlVal: "yaml_val", otherYamlKey: "other_yaml_key_val" };
 
-
         mockFileContents.set(getFixtureUri('main_include_yaml.json').fsPath, JSON.stringify(mainContent));
-        mockFileContents.set(getFixtureUri('data.yaml').fsPath, yamlContentString); // Store raw YAML string
+        mockFileContents.set(getFixtureUri('data.yaml').fsPath, yamlContentString);
 
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        await setupAndPreview('{{ mainJsonVal }} {{ yamlVal }} {{ otherYamlKey }}', 'dummy.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
 
         const expectedContext = {
             "mainJsonVal": "main_json_val",
-            ...expectedYamlParsed, // Spread the parsed YAML content
+            ...expectedYamlParsed,
             "_jinjer_include_contexts": ["data.yaml"]
         };
         assert.deepStrictEqual(contextUsed, expectedContext);
     });
 
     test('Absolute Path Include (mocked as absolute)', async () => {
-        mockGlobalConfig['contextFile'] = 'main_absolute_include.json';
-        const includePathString = '/abs_path_to/absolute_target.json'; // Path that isAbsolute will be true for
+        mockJinjerConfig.contextFile = 'main_absolute_include.json';
+        const includePathString = '/abs_path_to/absolute_target.json';
 
         const mainContent = { "mainVal": "main_abs_val", "_jinjer_include_contexts": [includePathString] };
         const absoluteTargetContent = { "absTargetVal": "abs_target_val" };
 
-        // Main file is relative to testFixtureRoot
         mockFileContents.set(getFixtureUri('main_absolute_include.json').fsPath, JSON.stringify(mainContent));
-        // The "absolute" file's content is keyed by the exact path string used in the include
-        mockFileContents.set(includePathString, JSON.stringify(absoluteTargetContent));
+        mockFileContents.set(includePathString, JSON.stringify(absoluteTargetContent)); // Keyed by the "absolute" path
 
+        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => p === includePathString);
+        testSuiteStubs.push(pathIsAbsoluteStub);
 
-        // Stub path.isAbsolute for this test case
-        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
-            if (p === includePathString) {
-                return true;
-            }
-            // Fallback to original for other paths if any are checked (though unlikely in this specific code path)
-            // For a more robust stub, you might need to call original `path.isAbsolute` for other paths.
-            // However, loadContextRecursive only calls it for includePathString.
-            return false; // Default for any other path it might be called with in this test's context.
-        });
-        stubs.push(pathIsAbsoluteStub); // Manage this stub for cleanup by the main teardown
-
-        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
-        spies.push(renderStringSpy);
-
-        // The 'dummy_abs.j2' is just to provide a starting point for findContextFile.
-        // main_absolute_include.json will be found relative to testFixtureRoot.
-        await setupAndPreview('{{ mainVal }} {{ absTargetVal }}', 'dummy_abs.j2');
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
 
         assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
         const contextUsed = renderStringSpy.lastCall.args[1];
@@ -1133,6 +1078,5 @@ suite('Context Inclusion Tests', () => {
         assert.deepStrictEqual(contextUsed, expectedContext);
         assert.ok(pathIsAbsoluteStub.calledWith(includePathString), 'path.isAbsolute was not called with the include string');
     });
-
-    // All context inclusion tests are now added.
 });
+// --- End of Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -649,6 +649,8 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
 });
 
+});
+
 // --- Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---
 suite('Context Inclusion Tests (New)', () => {
     let testSuiteStubs: sinon.SinonStub[] = [];
@@ -1075,6 +1077,155 @@ suite('Context Inclusion Tests (New)', () => {
         };
         assert.deepStrictEqual(contextUsed, expectedContext);
         assert.ok(pathIsAbsoluteStub.calledWith(includePathString), 'path.isAbsolute was not called with the include string');
+    });
+
+    test('Should skip include outside workspace (relative path)', async () => {
+        mockJinjerConfig.contextFile = 'main_includes_outside_relative.json';
+
+        const mainContent = {
+            "mainVal": "m1",
+            "_jinjer_include_contexts": ["../outside_file.json"]
+        };
+        const outsideContent = { "outsideVal": "val_outside" };
+
+        mockFileContents.set(getFixtureUri('main_includes_outside_relative.json').fsPath, JSON.stringify(mainContent));
+        const outsideFilePath = path.resolve(mockWorkspaceFolder.uri.fsPath, '../outside_file.json');
+        mockFileContents.set(outsideFilePath, JSON.stringify(outsideContent));
+
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
+
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, {
+            "mainVal": "m1",
+            "_jinjer_include_contexts": ["../outside_file.json"]
+        }, "Context should not contain data from outside_file.json");
+
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(/is outside the current workspace/)), 'Expected console.warn for outside workspace');
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(path.basename(outsideFilePath))), 'Warning should mention the problematic file path');
+    });
+
+    test('Should skip include outside workspace (absolute path)', async () => {
+        mockJinjerConfig.contextFile = 'main_includes_outside_absolute.json';
+        const tempDir = require('os').tmpdir();
+        const absoluteOutsidePath = path.normalize(path.join(tempDir, 'jinjer_test_outside_abs.json'));
+
+        const mainContent = {
+            "mainVal": "m2",
+            "_jinjer_include_contexts": [absoluteOutsidePath]
+        };
+        const outsideContent = { "outsideAbsVal": "val_abs_outside" };
+
+        mockFileContents.set(getFixtureUri('main_includes_outside_absolute.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(absoluteOutsidePath, JSON.stringify(outsideContent));
+
+        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
+            if (p === absoluteOutsidePath) return true;
+            return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
+        });
+        testSuiteStubs.push(pathIsAbsoluteStub);
+
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
+
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, {
+            "mainVal": "m2",
+            "_jinjer_include_contexts": [absoluteOutsidePath]
+        }, "Context should not contain data from absolute_outside_file.json");
+
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(/is outside the current workspace/)), 'Expected console.warn for outside workspace');
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(path.basename(absoluteOutsidePath))), 'Warning should mention the problematic file path');
+    });
+
+    test('Should load include inside workspace (absolute path)', async () => {
+        mockJinjerConfig.contextFile = 'main_includes_inside_absolute.json';
+        const absoluteInsidePath = path.join(mockWorkspaceFolder.uri.fsPath, 'included_abs_inside.json');
+
+        const mainContent = {
+            "mainVal": "m3",
+            "_jinjer_include_contexts": [absoluteInsidePath]
+        };
+        const insideContent = { "insideAbsVal": "val_abs_inside" };
+
+        mockFileContents.set(getFixtureUri('main_includes_inside_absolute.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(absoluteInsidePath, JSON.stringify(insideContent));
+
+        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
+            if (p === absoluteInsidePath) return true;
+            return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
+        });
+        testSuiteStubs.push(pathIsAbsoluteStub);
+
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
+
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, {
+            "mainVal": "m3",
+            "insideAbsVal": "val_abs_inside",
+            "_jinjer_include_contexts": [absoluteInsidePath]
+        }, "Context should contain data from absolute_inside_file.json");
+
+        const warningCall = consoleWarnSpy.getCalls().find(call => call.args.some((arg: string) => typeof arg === 'string' && arg.includes('is outside the current workspace')));
+        assert.strictEqual(warningCall, undefined, 'Should not warn for valid absolute path inside workspace');
+    });
+
+    test('Should load absolute include when no workspace is open', async () => {
+        // Simulate no workspace being open
+        const getWorkspaceFolderStubInstance = testSuiteStubs.find(s => s.stub && s.stub.name === 'getWorkspaceFolder'); // Assuming stubs are named or identifiable
+        if (getWorkspaceFolderStubInstance && (getWorkspaceFolderStubInstance as sinon.SinonStub).name === 'getWorkspaceFolder') { // Check if it's the correct stub
+            (getWorkspaceFolderStubInstance as sinon.SinonStub).returns(undefined);
+        } else {
+            // This is a fallback or error if the specific stub isn't found as expected.
+            // This indicates a potential issue in how stubs are stored or named in setup.
+            // For this test, we'll proceed, but ideally the stub should be precisely controlled.
+            console.warn("Test 'Should load absolute include when no workspace is open': Could not reliably modify getWorkspaceFolder stub. It might have been already restored or not named.");
+            // If it's critical, re-stub it and add to testSuiteStubs for this test only.
+            const tempGetWorkspaceFolderStub = sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined);
+            testSuiteStubs.push(tempGetWorkspaceFolderStub); // Ensure this temporary stub is cleaned up
+        }
+
+        const looseFileDir = require('os').tmpdir();
+        const looseFileName = 'loosefile_for_no_ws_test.j2';
+        const looseFileUri = vscode.Uri.file(path.join(looseFileDir, looseFileName));
+
+        if (activeTextEditorStub && typeof activeTextEditorStub.restore === 'function') {
+            activeTextEditorStub.restore();
+        }
+        activeTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').returns({
+            document: { uri: looseFileUri, fileName: looseFileUri.fsPath, getText: () => "{{mainVal}} {{absVal}}" }
+        } as any);
+        testSuiteStubs.push(activeTextEditorStub);
+
+        mockJinjerConfig.contextFile = 'main_abs_include_no_workspace.json';
+        const absoluteIncludePath = path.resolve(require('os').tmpdir(), 'abs_data_no_ws.json');
+
+        const mainContent = { "mainVal": "m4", "_jinjer_include_contexts": [absoluteIncludePath] };
+        const includeContent = { "absVal": "val_abs_no_ws" };
+
+        // Main context file is relative to the loose file itself
+        mockFileContents.set(path.join(looseFileDir, 'main_abs_include_no_workspace.json'), JSON.stringify(mainContent));
+        mockFileContents.set(absoluteIncludePath, JSON.stringify(includeContent));
+
+        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
+            if (p === absoluteIncludePath) return true;
+            return require('path').posix.isAbsolute(p) || require('path').win32.isAbsolute(p);
+        });
+        testSuiteStubs.push(pathIsAbsoluteStub);
+
+        await vscode.commands.executeCommand('jinjer.preview');
+        await delay(100);
+
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, {
+            "mainVal": "m4",
+            "absVal": "val_abs_no_ws",
+            "_jinjer_include_contexts": [absoluteIncludePath]
+        }, "Context should load absolute path when no workspace is open");
+
+        const warningCall = consoleWarnSpy.getCalls().find(call => call.args.some((arg: string) => typeof arg === 'string' && arg.includes('is outside the current workspace')));
+        assert.strictEqual(warningCall, undefined, 'Should not warn about workspace boundary if no workspace is open');
     });
 });
 // --- End of Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -167,6 +167,7 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
     // Spy on nunjucks.configure
     let nunjucksConfigureSpy: sinon.SinonSpy;
+    let renderStringSpy: sinon.SinonSpy; // Declare renderStringSpy in the outer suite
 
     setup(() => {
         // Default mock states
@@ -233,6 +234,10 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
         // Spy on nunjucks.configure - ensure it's reset for each test
         nunjucksConfigureSpy = sinon.spy(nunjucks, 'configure');
         spies.push(nunjucksConfigureSpy);
+
+        // Spy on nunjucks.Environment.prototype.renderString - ensure it's reset for each test
+        renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
 
         // Reset the panel's HTML content before each test
         mockWebviewPanel.webview.html = '';
@@ -437,6 +442,94 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
                 Array.isArray(configureArgs) && !configureArgs.includes(globalPathToAvoid),
                 `Nunjucks configure args included global search path when it should have been overridden. Got: ${JSON.stringify(configureArgs)}`
             );
+        });
+
+        test('Should use contextIncludeKey from .jinjer-settings.json, overriding VSCode settings', async () => {
+            // Set a VS Code setting for contextIncludeKey
+            mockGlobalConfig.contextIncludeKey = '_vscode_key_';
+
+            // Define .jinjer-settings.json content with a different contextIncludeKey
+            const wsSettingsValues = {
+                contextFile: 'ws_ctx_for_include_key_override.json',
+                variableSuffix: 'ws',
+                customSearchPath: 'includes',
+                contextIncludeKey: '_ws_override_key_' // The override from .jinjer-settings.json
+            };
+            mockFileContents.set(workspaceSettingsFilePath, JSON.stringify(wsSettingsValues));
+
+            // Define main context file and included file using the _ws_override_key_
+            const mainContextContent = {
+                "mainVal": "mainDataValue",
+                "_ws_override_key_": ["included_by_ws_key.json"]
+            };
+            const includedContextContent = { "incVal": "dataFromWsOverride" };
+
+            const mainContextPath = path.join(mockWorkspaceFolder!.uri.fsPath, wsSettingsValues.contextFile);
+            mockFileContents.set(mainContextPath, JSON.stringify(mainContextContent));
+            mockFileContents.set(path.join(mockWorkspaceFolder!.uri.fsPath, 'included_by_ws_key.json'), JSON.stringify(includedContextContent));
+
+            await setupAndPreview('Template: {{ ws.mainVal }} - {{ ws.incVal }}', 'template_ws_key_override.j2');
+
+            const contextSentToNunjucks = renderStringSpy.lastCall.args[1];
+            assert.strictEqual(contextSentToNunjucks.ws.mainVal, "mainDataValue", "Test 1: Main value mismatch");
+            assert.strictEqual(contextSentToNunjucks.ws.incVal, "dataFromWsOverride", "Test 1: Included value mismatch - .jinjer-settings.json key override failed");
+        });
+
+        test('Should use VSCode contextIncludeKey if not set in .jinjer-settings.json', async () => {
+            mockGlobalConfig.contextIncludeKey = '_vscode_key_for_fallback_';
+
+            const wsSettingsValues = {
+                contextFile: 'ws_ctx_for_vscode_key_fallback.json',
+                variableSuffix: 'ws',
+                customSearchPath: 'includes'
+                // No contextIncludeKey here
+            };
+            mockFileContents.set(workspaceSettingsFilePath, JSON.stringify(wsSettingsValues));
+
+            const mainContextContent = {
+                "mainVal": "mainDataValue2",
+                "_vscode_key_for_fallback_": ["included_by_vscode_key.json"]
+            };
+            const includedContextContent = { "incVal": "dataFromVSCodeKeyFallback" };
+
+            const mainContextPath = path.join(mockWorkspaceFolder!.uri.fsPath, wsSettingsValues.contextFile);
+            mockFileContents.set(mainContextPath, JSON.stringify(mainContextContent));
+            mockFileContents.set(path.join(mockWorkspaceFolder!.uri.fsPath, 'included_by_vscode_key.json'), JSON.stringify(includedContextContent));
+
+            await setupAndPreview('Template: {{ ws.mainVal }} - {{ ws.incVal }}', 'template_vscode_key_fallback.j2');
+
+            const contextSentToNunjucks = renderStringSpy.lastCall.args[1];
+            assert.strictEqual(contextSentToNunjucks.ws.mainVal, "mainDataValue2", "Test 2: Main value mismatch");
+            assert.strictEqual(contextSentToNunjucks.ws.incVal, "dataFromVSCodeKeyFallback", "Test 2: Included value mismatch - VSCode key fallback failed");
+        });
+
+        test('Should use default contextIncludeKey if not in .jinjer-settings.json or VSCode settings', async () => {
+            delete mockGlobalConfig.contextIncludeKey;
+
+            const wsSettingsValues = {
+                contextFile: 'ws_ctx_for_default_key_fallback.json',
+                variableSuffix: 'ws',
+                customSearchPath: 'includes'
+                // No contextIncludeKey here
+            };
+            mockFileContents.set(workspaceSettingsFilePath, JSON.stringify(wsSettingsValues));
+
+            const packageDefaultKey = "_jinjer_include_contexts";
+            const mainContextContent = {
+                "mainVal": "mainDataValue3",
+                [packageDefaultKey]: ["included_by_default_key.json"]
+            };
+            const includedContextContent = { "incVal": "dataFromDefaultKey" };
+
+            const mainContextPath = path.join(mockWorkspaceFolder!.uri.fsPath, wsSettingsValues.contextFile);
+            mockFileContents.set(mainContextPath, JSON.stringify(mainContextContent));
+            mockFileContents.set(path.join(mockWorkspaceFolder!.uri.fsPath, 'included_by_default_key.json'), JSON.stringify(includedContextContent));
+
+            await setupAndPreview('Template: {{ ws.mainVal }} - {{ ws.incVal }}', 'template_default_key_fallback.j2');
+
+            const contextSentToNunjucks = renderStringSpy.lastCall.args[1];
+            assert.strictEqual(contextSentToNunjucks.ws.mainVal, "mainDataValue3", "Test 3: Main value mismatch");
+            assert.strictEqual(contextSentToNunjucks.ws.incVal, "dataFromDefaultKey", "Test 3: Included value mismatch - package.json default key fallback failed");
         });
     });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -646,20 +646,22 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
 // --- Suite for Context Inclusion Tests ---
 suite('Context Inclusion Tests', () => {
-    let mockFileContents: Map<string, string>;
-    let mockWorkspaceFolder: vscode.WorkspaceFolder;
+    // REMOVED: let mockFileContents: Map<string, string>;
+    // We will use mockFileContents from the outer suite scope.
+    let mockWorkspaceFolder: vscode.WorkspaceFolder; // This is fine, it's specific to this suite's setup.
     const testFixtureRoot = path.resolve(__dirname, 'testFixture', 'contextIncludes'); // Adjusted path
 
     // Helper to get the URI for a test fixture file
     const getFixtureUri = (fileName: string) => vscode.Uri.file(path.join(testFixtureRoot, fileName));
 
-    // This will hold the original getConfiguration stub
-    let originalGetConfiguration: sinon.SinonStub | undefined;
+    // This will hold the original getConfiguration stub if we were to capture it,
+    // but since we are REMOVING the inner stub, this might not be needed here.
+    // let originalGetConfiguration: sinon.SinonStub | undefined;
 
     setup(async () => {
-        mockFileContents = new Map(); // Reset for each test
-        mockWorkspaceFolder = {
-            uri: vscode.Uri.file(testFixtureRoot), // Base tests out of the contextIncludes directory
+        // mockFileContents is from the outer scope. It will be cleared in beforeEach.
+        mockWorkspaceFolder = { // This mockWorkspaceFolder is specific to this suite's tests
+            uri: vscode.Uri.file(testFixtureRoot),
             name: 'ContextIncludesTestWorkspace',
             index: 0
         };
@@ -687,47 +689,15 @@ suite('Context Inclusion Tests', () => {
         // A better way: the outer suite's `mockFileContents` should be cleared and re-populated here.
         // Or, `setupAndPreview` needs to be adapted, or we create a new `getTestData` that sets up its own mocks for fs.
 
-        // Stubbing getConfiguration specifically for this suite to control jinjer settings
-        // This will override the global one. Remember to restore it.
-        if (vscode.workspace.getConfiguration && (vscode.workspace.getConfiguration as any).isSinonProxy) {
-            originalGetConfiguration = vscode.workspace.getConfiguration as sinon.SinonStub;
-        }
+        // REMOVED: Stubbing of vscode.workspace.getConfiguration from inner suite's setup.
+        // The tests in this suite will rely on the getConfiguration stub from the outer suite,
+        // and will modify the shared mockGlobalConfig in beforeEach or directly in tests.
 
-        stubs.push(sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section) => {
-            if (section === 'jinjer') {
-                // Use a new config object for each call to getConfiguration within this suite
-                // to ensure test isolation for config values.
-                const testSpecificConfig = { ...mockGlobalConfig }; // Start with outer suite's global config
-
-                // Apply defaults or test-specific overrides for context inclusion tests
-                testSpecificConfig['contextIncludeKey'] = testSpecificConfig['contextIncludeKey'] ?? '_jinjer_include_contexts';
-                testSpecificConfig['contextFile'] = testSpecificConfig['contextFile'] ?? 'context.json';
-                testSpecificConfig['variableSuffix'] = testSpecificConfig['variableSuffix'] ?? '';
-
-
-                return {
-                    get: (key: string) => testSpecificConfig[key],
-                    has: (key: string) => key in testSpecificConfig,
-                    inspect: (key: string) => ({
-                        key: `jinjer.${key}`,
-                        globalValue: testSpecificConfig[key],
-                        workspaceValue: undefined, // Not mocking workspace value overrides here yet
-                        defaultValue: undefined
-                    }),
-                    update: sinon.stub().callsFake(async (key: string, value: any) => {
-                        mockGlobalConfig[key] = value; // Update the shared mockGlobalConfig
-                        return Promise.resolve();
-                    })
-                };
-            }
-            // Fallback to original stub for other sections if it was captured
-            if (originalGetConfiguration) {
-                return originalGetConfiguration(section);
-            }
-            // Default fallback if originalGetConfiguration was not captured (e.g. first run)
-            return { get: sinon.stub().returns(undefined), has: sinon.stub().returns(false), inspect: sinon.stub().returns(undefined), update: sinon.stub().resolves() } as any;
-        }));
-
+        // The following stubs for activeTextEditor and getWorkspaceFolder are also potentially
+        // redundant if the outer suite's setup is sufficient and mockWorkspaceFolder is
+        // updated correctly for this suite's context.
+        // For now, these are kept as they might be providing suite-specific behavior for these elements.
+        // However, they also push to the global `stubs` array.
 
         // Populate mockFileContents with actual files from the testFixture directory
         // This is crucial. The tests will rely on `fs.readFile` stub to provide these.
@@ -757,14 +727,12 @@ suite('Context Inclusion Tests', () => {
     });
 
     teardown(async () => {
-        // Restore specific stubs for this suite
-        stubs.forEach(s => s.restore()); // This might be too broad if outer suite stubs are in same array
-        stubs = []; // Clear local stubs list
-        if (originalGetConfiguration) {
-            (vscode.workspace.getConfiguration as sinon.SinonStub).restore(); // Restore original stub
-            originalGetConfiguration = undefined;
-        }
-        // Clean up global config updates if any were made directly
+        // The stubs pushed by this suite's setup (if any remain) and by individual tests
+        // (e.g. path.isAbsolute stub, console.warn spy) are added to the global `stubs` and `spies`
+        // arrays, which are cleaned by the outer suite's teardown. So, no specific teardown
+        // for stubs is needed here if that system works as intended.
+
+        // Clean up global config updates specifically made by this suite's tests/beforeEach
         await vscode.workspace.getConfiguration('jinjer').update('contextIncludeKey', undefined, vscode.ConfigurationTarget.Global);
         await vscode.workspace.getConfiguration('jinjer').update('contextFile', undefined, vscode.ConfigurationTarget.Global);
     });
@@ -782,23 +750,22 @@ suite('Context Inclusion Tests', () => {
     // `spies` array is from the outer suite for centralized cleanup.
 
     beforeEach(() => {
-        // Clear mock file contents before each test in this suite
-        // This assumes `mockFileContents` is the map used by the global `readFile` and `stat` stubs
-        if (globalThis.mockFileContents && typeof globalThis.mockFileContents.clear === 'function') {
-            globalThis.mockFileContents.clear();
-        } else if (mockFileContents && typeof mockFileContents.clear === 'function') {
-            // If mockFileContents is scoped to this file (as it appears to be in the provided code)
+        // Clear the mockFileContents from the outer suite.
+        if (mockFileContents && typeof mockFileContents.clear === 'function') {
             mockFileContents.clear();
+        } else {
+            // This case should ideally not happen if mockFileContents is correctly from the outer scope.
+            // console.warn("Context Inclusion Tests: Outer mockFileContents not found or not a Map.");
         }
-        // Reset relevant parts of global config, or set defaults for this suite
-        if (globalThis.mockGlobalConfig) {
-            globalThis.mockGlobalConfig['contextIncludeKey'] = '_jinjer_include_contexts';
-            globalThis.mockGlobalConfig['contextFile'] = 'context.json'; // Default for most tests
-            globalThis.mockGlobalConfig['variableSuffix'] = ''; // No suffix by default
-        } else if (mockGlobalConfig) {
+
+        // Reset relevant parts of the outer mockGlobalConfig, or set defaults for this suite
+        if (mockGlobalConfig) {
             mockGlobalConfig['contextIncludeKey'] = '_jinjer_include_contexts';
-            mockGlobalConfig['contextFile'] = 'context.json';
-            mockGlobalConfig['variableSuffix'] = '';
+            mockGlobalConfig['contextFile'] = 'context.json'; // Default for most tests
+            mockGlobalConfig['variableSuffix'] = ''; // No suffix by default
+        } else {
+            // This case should ideally not happen.
+            // console.warn("Context Inclusion Tests: Outer mockGlobalConfig not found.");
         }
     });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -158,10 +158,11 @@ class MockLanguageModelAccessInformation implements vscode.LanguageModelAccessIn
 
 // --- Main Test Suite ---
 suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
-    let mockGlobalConfig: any;
-    let mockWorkspaceConfig: any;
+    const mockFileContents: Map<string, string> = new Map(); // Initialized
+    const mockGlobalConfig: { [key: string]: any } = {};   // Initialized
+
+    let mockWorkspaceConfig: any; // This is reset in each outer setup, so `let` is fine.
     let mockWorkspaceSettingsContent: string | undefined;
-    let mockFileContents: Map<string, string>; // path -> content
     let mockWorkspaceFolder: vscode.WorkspaceFolder | undefined;
 
     // Spy on nunjucks.configure
@@ -169,11 +170,13 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
     setup(() => {
         // Default mock states
-        mockGlobalConfig = {};
+        mockFileContents.clear();
+        Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
+        // mockGlobalConfig can be seeded with common defaults here if necessary after clearing
+
         mockWorkspaceConfig = {}; // For workspace-level VS Code settings (distinct from .jinjer-settings.json)
         mockWorkspaceSettingsContent = undefined;
-        mockFileContents = new Map();
-        mockWorkspaceFolder = {
+        mockWorkspaceFolder = { // This is the default for the outer suite; inner suites might override locally
             uri: vscode.Uri.file(path.resolve('/fake/workspace')),
             name: 'FakeWorkspace',
             index: 0

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -649,8 +649,6 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
 });
 
-});
-
 // --- Suite for Context Inclusion Tests (NEW, ISOLATED SETUP) ---
 suite('Context Inclusion Tests (New)', () => {
     let testSuiteStubs: sinon.SinonStub[] = [];

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -643,3 +643,523 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
     });
 
 });
+
+// --- Suite for Context Inclusion Tests ---
+suite('Context Inclusion Tests', () => {
+    let mockFileContents: Map<string, string>;
+    let mockWorkspaceFolder: vscode.WorkspaceFolder;
+    const testFixtureRoot = path.resolve(__dirname, 'testFixture', 'contextIncludes'); // Adjusted path
+
+    // Helper to get the URI for a test fixture file
+    const getFixtureUri = (fileName: string) => vscode.Uri.file(path.join(testFixtureRoot, fileName));
+
+    // This will hold the original getConfiguration stub
+    let originalGetConfiguration: sinon.SinonStub | undefined;
+
+    setup(async () => {
+        mockFileContents = new Map(); // Reset for each test
+        mockWorkspaceFolder = {
+            uri: vscode.Uri.file(testFixtureRoot), // Base tests out of the contextIncludes directory
+            name: 'ContextIncludesTestWorkspace',
+            index: 0
+        };
+
+        // Ensure the getConfiguration stub from the outer suite is available
+        // This is a bit tricky due to nested suites. We might need to re-stub or ensure it's broadly scoped.
+        // For simplicity, let's assume the outer suite's stubs are active or re-apply similar logic.
+
+        // Override vscode.workspace.fs.readFile and vscode.workspace.fs.stat for our test files
+        // These stubs are pushed to the global `stubs` array by the outer suite's setup.
+        // We need to ensure they are aware of our new mockFileContents map.
+        // The best approach is to ensure the stubs created in the outer suite's setup
+        // use the `mockFileContents` and `mockWorkspaceFolder` that we can update here.
+        // This requires `mockFileContents` and `mockWorkspaceFolder` to be declared at a scope accessible
+        // to the `readFile` and `stat` stubs. Let's assume they are, or adjust.
+        // For this example, I'll re-define the stubs for fs operations to be self-contained for this suite
+        // if necessary, or rely on careful ordering and cleanup.
+
+        // The existing stubs for fs.readFile and fs.stat should be fine if they use a shared, updatable mockFileContents.
+        // Let's ensure our local mockFileContents is used by those stubs.
+        // This might involve directly manipulating the map used by the outer stubs, or re-stubbing.
+        // For now, let's assume we can populate the `mockFileContents` map that the existing stubs use.
+        // This requires `mockFileContents` from the outer scope to be assigned here.
+        // This is problematic with strict `let` scoping in `setup`.
+        // A better way: the outer suite's `mockFileContents` should be cleared and re-populated here.
+        // Or, `setupAndPreview` needs to be adapted, or we create a new `getTestData` that sets up its own mocks for fs.
+
+        // Stubbing getConfiguration specifically for this suite to control jinjer settings
+        // This will override the global one. Remember to restore it.
+        if (vscode.workspace.getConfiguration && (vscode.workspace.getConfiguration as any).isSinonProxy) {
+            originalGetConfiguration = vscode.workspace.getConfiguration as sinon.SinonStub;
+        }
+
+        stubs.push(sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section) => {
+            if (section === 'jinjer') {
+                // Use a new config object for each call to getConfiguration within this suite
+                // to ensure test isolation for config values.
+                const testSpecificConfig = { ...mockGlobalConfig }; // Start with outer suite's global config
+
+                // Apply defaults or test-specific overrides for context inclusion tests
+                testSpecificConfig['contextIncludeKey'] = testSpecificConfig['contextIncludeKey'] ?? '_jinjer_include_contexts';
+                testSpecificConfig['contextFile'] = testSpecificConfig['contextFile'] ?? 'context.json';
+                testSpecificConfig['variableSuffix'] = testSpecificConfig['variableSuffix'] ?? '';
+
+
+                return {
+                    get: (key: string) => testSpecificConfig[key],
+                    has: (key: string) => key in testSpecificConfig,
+                    inspect: (key: string) => ({
+                        key: `jinjer.${key}`,
+                        globalValue: testSpecificConfig[key],
+                        workspaceValue: undefined, // Not mocking workspace value overrides here yet
+                        defaultValue: undefined
+                    }),
+                    update: sinon.stub().callsFake(async (key: string, value: any) => {
+                        mockGlobalConfig[key] = value; // Update the shared mockGlobalConfig
+                        return Promise.resolve();
+                    })
+                };
+            }
+            // Fallback to original stub for other sections if it was captured
+            if (originalGetConfiguration) {
+                return originalGetConfiguration(section);
+            }
+            // Default fallback if originalGetConfiguration was not captured (e.g. first run)
+            return { get: sinon.stub().returns(undefined), has: sinon.stub().returns(false), inspect: sinon.stub().returns(undefined), update: sinon.stub().resolves() } as any;
+        }));
+
+
+        // Populate mockFileContents with actual files from the testFixture directory
+        // This is crucial. The tests will rely on `fs.readFile` stub to provide these.
+        // We need a way to tell the `fs.readFile` stub about these files.
+        // The simplest is to load them into the globally defined `mockFileContents` from the outer suite.
+        // This is a bit of a hack due to test structure.
+        // A cleaner way would be for the `fs.readFile` stub itself to actually read from disk for test fixtures.
+        // For now, let's assume we'll manually populate `mockFileContents` in each test for the files it needs.
+        // Or, even better, make `getTestData` set up the `mockFileContents` for the specific context files.
+
+        // Reset active document for `getContextData` which relies on `vscode.window.activeTextEditor`
+        // The `getContextData` function itself doesn't use the content of the activeTextEditor,
+        // only its URI to find the workspace and search for context files.
+        const dummyDocUri = vscode.Uri.joinPath(mockWorkspaceFolder.uri, 'dummy_template.j2');
+        const mockEditor = {
+            document: { uri: dummyDocUri, fileName: dummyDocUri.fsPath, getText: () => "" }
+        };
+        // Ensure existing stub is restored before creating a new one or use .returns() to change behavior
+        let activeTextEditorStub = stubs.find(s => s && s.name === 'activeTextEditorStub' && (s as any).stub);
+        if (activeTextEditorStub) {
+            (activeTextEditorStub as sinon.SinonStub).returns(mockEditor);
+        } else {
+            stubs.push(sinon.stub(vscode.window, 'activeTextEditor').named('activeTextEditorStub').returns(mockEditor));
+        }
+        stubs.push(sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(mockWorkspaceFolder));
+
+    });
+
+    teardown(async () => {
+        // Restore specific stubs for this suite
+        stubs.forEach(s => s.restore()); // This might be too broad if outer suite stubs are in same array
+        stubs = []; // Clear local stubs list
+        if (originalGetConfiguration) {
+            (vscode.workspace.getConfiguration as sinon.SinonStub).restore(); // Restore original stub
+            originalGetConfiguration = undefined;
+        }
+        // Clean up global config updates if any were made directly
+        await vscode.workspace.getConfiguration('jinjer').update('contextIncludeKey', undefined, vscode.ConfigurationTarget.Global);
+        await vscode.workspace.getConfiguration('jinjer').update('contextFile', undefined, vscode.ConfigurationTarget.Global);
+    });
+
+    /**
+     * Helper function to simulate file system for context loading tests.
+     * It populates the mockFileContents map which is used by the fs.readFile stub.
+     * It then calls the actual getContextData function (assuming it's exported).
+     * @param mainDocumentName The name of the "template" file, used to determine search start.
+     * @param contextFileName The name of the context file to search for.
+     * @param filesToMock A map where keys are file names (relative to testFixtureRoot) and values are their content.
+     */
+    // `mockFileContents` and `mockGlobalConfig` are from the outer suite.
+    // `setupAndPreview` is also from the outer suite.
+    // `spies` array is from the outer suite for centralized cleanup.
+
+    beforeEach(() => {
+        // Clear mock file contents before each test in this suite
+        // This assumes `mockFileContents` is the map used by the global `readFile` and `stat` stubs
+        if (globalThis.mockFileContents && typeof globalThis.mockFileContents.clear === 'function') {
+            globalThis.mockFileContents.clear();
+        } else if (mockFileContents && typeof mockFileContents.clear === 'function') {
+            // If mockFileContents is scoped to this file (as it appears to be in the provided code)
+            mockFileContents.clear();
+        }
+        // Reset relevant parts of global config, or set defaults for this suite
+        if (globalThis.mockGlobalConfig) {
+            globalThis.mockGlobalConfig['contextIncludeKey'] = '_jinjer_include_contexts';
+            globalThis.mockGlobalConfig['contextFile'] = 'context.json'; // Default for most tests
+            globalThis.mockGlobalConfig['variableSuffix'] = ''; // No suffix by default
+        } else if (mockGlobalConfig) {
+            mockGlobalConfig['contextIncludeKey'] = '_jinjer_include_contexts';
+            mockGlobalConfig['contextFile'] = 'context.json';
+            mockGlobalConfig['variableSuffix'] = '';
+        }
+    });
+
+    test('No Include Key', async () => {
+        mockGlobalConfig['contextFile'] = 'main_no_include.json';
+        const mainContent = { val: "main_no_include_val" };
+        mockFileContents.set(getFixtureUri('main_no_include.json').fsPath, JSON.stringify(mainContent));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ val }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, mainContent);
+    });
+
+    test('Empty Include List', async () => {
+        mockGlobalConfig['contextFile'] = 'main_empty_include.json';
+        const mainContent = { val: "main_empty_include_val", "_jinjer_include_contexts": [] };
+        mockFileContents.set(getFixtureUri('main_empty_include.json').fsPath, JSON.stringify(mainContent));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ val }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+        assert.deepStrictEqual(contextUsed, mainContent);
+    });
+
+    test('Single Include', async () => {
+        mockGlobalConfig['contextFile'] = 'main_single_include.json'; // Set the main context file for the test
+
+        const mainContent = { "mainVal": "m_single", "_jinjer_include_contexts": ["include1.json"] };
+        const include1Content = { "inclVal": "i1_single" };
+
+        // Populate the mock file system
+        mockFileContents.set(getFixtureUri('main_single_include.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(getFixtureUri('include1.json').fsPath, JSON.stringify(include1Content));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy); // Add to global spies list for cleanup
+
+        // Trigger the preview. The active document URI helps locate the context file.
+        // The content of dummy.j2 doesn't matter, only its path for context resolution.
+        await setupAndPreview('{{ mainVal }} {{ inclVal }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsedByNunjucks = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainVal": "m_single",
+            "inclVal": "i1_single",
+            "_jinjer_include_contexts": ["include1.json"] // The include key itself remains
+        };
+        assert.deepStrictEqual(contextUsedByNunjucks, expectedContext);
+    });
+
+    test('Nested Include (Multi-Level)', async () => {
+        mockGlobalConfig['contextFile'] = 'main_multi_level.json';
+
+        const mainContent = { "mainVal": "m_multi", "_jinjer_include_contexts": ["level1.json"] };
+        const level1Content = { "l1Val": "l1_multi", "_jinjer_include_contexts": ["level2.json"] };
+        const level2Content = { "l2Val": "l2_multi" };
+
+        mockFileContents.set(getFixtureUri('main_multi_level.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(getFixtureUri('level1.json').fsPath, JSON.stringify(level1Content));
+        mockFileContents.set(getFixtureUri('level2.json').fsPath, JSON.stringify(level2Content));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ mainVal }} {{ l1Val }} {{ l2Val }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainVal": "m_multi",
+            "l1Val": "l1_multi",
+            "l2Val": "l2_multi",
+            "_jinjer_include_contexts": ["level2.json"] // from level1.json, as it's merged last at that level
+        };
+        // The _jinjer_include_contexts from main.json is overwritten by level1.json's during merge.
+        // And level2.json has no include key, so level1's remains.
+        assert.deepStrictEqual(contextUsed, expectedContext);
+    });
+
+    test('Merge Conflict (Last Include Wins for conflicting keys)', async () => {
+        mockGlobalConfig['contextFile'] = 'main_conflict.json';
+
+        const mainContent = { "key": "main_val", "mainOnlyKey": "main_only_val", "_jinjer_include_contexts": ["conflict_source.json"] };
+        const conflictContent = { "key": "conflict_val", "conflictOnlyKey": "conflict_only_val" };
+
+        mockFileContents.set(getFixtureUri('main_conflict.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(getFixtureUri('conflict_source.json').fsPath, JSON.stringify(conflictContent));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ key }} {{ mainOnlyKey }} {{ conflictOnlyKey }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "key": "conflict_val", // Value from conflict_source.json should overwrite main.json
+            "mainOnlyKey": "main_only_val",
+            "conflictOnlyKey": "conflict_only_val",
+            "_jinjer_include_contexts": ["conflict_source.json"]
+        };
+        assert.deepStrictEqual(contextUsed, expectedContext);
+    });
+
+    test('Relative Path Navigation(../common.json)', async () => {
+        // The context file to be found is 'base/main_relative_up.json'
+        // So, the "active document" for context searching needs to be conceptually in the 'base' subdir
+        // or the contextFile path needs to be 'base/main_relative_up.json'.
+        // Let's make the active document in 'base' so findContextFile starts searching from there.
+        mockGlobalConfig['contextFile'] = 'main_relative_up.json'; // This file will be searched for starting from dummy_in_base.j2's dir.
+
+        const mainContent = { "mainVal": "main_relative_up_val", "_jinjer_include_contexts": ["../common_data.json"] };
+        const commonDataContent = { "commonVal": "common_data_val" };
+
+        // main_relative_up.json is in base/
+        mockFileContents.set(getFixtureUri('base/main_relative_up.json').fsPath, JSON.stringify(mainContent));
+        // common_data.json is in the parent of base/ (which is testFixtureRoot)
+        mockFileContents.set(getFixtureUri('common_data.json').fsPath, JSON.stringify(commonDataContent));
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        // The dummy template is effectively at 'testFixtureRoot/base/dummy_in_base.j2'
+        // This ensures getContextData starts searching for 'main_relative_up.json' from the 'base' directory.
+        await setupAndPreview('{{ mainVal }} {{ commonVal }}', 'base/dummy_in_base.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainVal": "main_relative_up_val",
+            "commonVal": "common_data_val",
+            "_jinjer_include_contexts": ["../common_data.json"]
+        };
+        assert.deepStrictEqual(contextUsed, expectedContext);
+    });
+
+    test('Relative Path Include (./subdir/file.json)', async () => {
+        mockGlobalConfig['contextFile'] = 'main_relative_path.json';
+
+        const mainContent = { "mainVal": "main_relative_val", "_jinjer_include_contexts": ["./subdir/relative.json"] };
+        const relativeContent = { "relativeVal": "relative_subdir_val" };
+
+        mockFileContents.set(getFixtureUri('main_relative_path.json').fsPath, JSON.stringify(mainContent));
+        // The path for relative.json should be testFixtureRoot + '/subdir/relative.json'
+        mockFileContents.set(getFixtureUri('subdir/relative.json').fsPath, JSON.stringify(relativeContent));
+
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        // The main_relative_path.json is at the root of testFixtureRoot for context searching.
+        // The include path ./subdir/relative.json will be resolved from testFixtureRoot.
+        await setupAndPreview('{{ mainVal }} {{ relativeVal }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainVal": "main_relative_val",
+            "relativeVal": "relative_subdir_val",
+            "_jinjer_include_contexts": ["./subdir/relative.json"]
+        };
+        assert.deepStrictEqual(contextUsed, expectedContext);
+    });
+
+    test('Circular Dependency', async () => {
+        mockGlobalConfig['contextFile'] = 'main_circular_a.json';
+
+        const circAContent = { "val_a": "a", "shared_key": "from_a", "_jinjer_include_contexts": ["main_circular_b.json"] };
+        const circBContent = { "val_b": "b", "shared_key": "from_b", "_jinjer_include_contexts": ["main_circular_a.json"] };
+
+        mockFileContents.set(getFixtureUri('main_circular_a.json').fsPath, JSON.stringify(circAContent));
+        mockFileContents.set(getFixtureUri('main_circular_b.json').fsPath, JSON.stringify(circBContent));
+
+        // Spy on console.warn for circular dependency message
+        const consoleWarnSpy = sinon.spy(console, 'warn');
+        spies.push(consoleWarnSpy);
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ val_a }} {{ val_b }} {{ shared_key }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        // Expected: main_circular_a is loaded first. It tries to load main_circular_b.
+        // main_circular_b is loaded. It tries to load main_circular_a.
+        // main_circular_a is detected in processedPaths, so its content (as parsed initially) is returned to b.
+        // Then b's content (now merged with a's original) is returned to a.
+        // So, b's version of shared_key should win as it's merged into a.
+        const expectedContext = {
+            "val_a": "a",
+            "val_b": "b",
+            "shared_key": "from_a", // main_circular_a loads main_circular_b. main_circular_b's content is merged into main_circular_a.
+                                  // When main_circular_b tries to load main_circular_a again, it gets main_circular_a's content *without* a second merge of B.
+                                  // So, the content of A (which has its include key) is merged with B.
+                                  // A is target, B is source. B's shared_key overwrites A's.
+                                  // Wait, the deepMerge is (target, source).
+                                  // 1. Load A: {val_a, shared_key:from_a, _inc: [B]}
+                                  // 2. Process include B:
+                                  //    Load B: {val_b, shared_key:from_b, _inc: [A]}
+                                  //    Process include A for B: A is in processedPaths. Parse A: {val_a, shared_key:from_a, _inc: [B]}. This is `includedContext` for B.
+                                  //    Merge (B, A_parsed_raw): B = {...B, ...A_parsed_raw}. So B.shared_key becomes "from_a". B._inc becomes [B] from A.
+                                  //    Context from B's recursion: {val_b:"b", val_a:"a", shared_key:"from_a", _inc:[B]}
+                                  // 3. Merge B_processed into A: A = {...A, ...B_processed}
+                                  //    A.shared_key was "from_a", B_processed.shared_key is "from_a". So it's "from_a".
+                                  //    A._inc was [B], B_processed._inc is [B]. So it's [B].
+                                  // This implies shared_key should be "from_a".
+                                  // Let's trace again:
+                                  // loadRecursive(A, key, processed={}):
+                                  //  processed.add(A_path)
+                                  //  currentContextA = parse(A) = { val_a:"a", shared_key:"from_a", _inc:[B] }
+                                  //  loop include "B":
+                                  //   resolvedB = path_B
+                                  //   includedContextB = loadRecursive(B, key, processed={A_path}):
+                                  //    processed.add(B_path) -> processed={A_path, B_path}
+                                  //    currentContextB = parse(B) = { val_b:"b", shared_key:"from_b", _inc:[A] }
+                                  //    loop include "A":
+                                  //     resolvedA = path_A
+                                  //     A_path is in processedPaths. WARN circular.
+                                  //     return parse(A) = { val_a:"a", shared_key:"from_a", _inc:[B] } -> this is innerIncludedContextA
+                                  //    currentContextB = deepMerge(currentContextB, innerIncludedContextA)
+                                  //                = deepMerge({val_b:"b",shared_key:"from_b",_inc:[A]}, {val_a:"a",shared_key:"from_a",_inc:[B]})
+                                  //                = {val_b:"b", val_a:"a", shared_key:"from_a", _inc:[B]}
+                                  //    processed.delete(B_path)
+                                  //    return currentContextB -> this is includedContextB for A's load.
+                                  //  currentContextA = deepMerge(currentContextA, includedContextB)
+                                  //              = deepMerge({val_a:"a",shared_key:"from_a",_inc:[B]}, {val_b:"b",val_a:"a",shared_key:"from_a",_inc:[B]})
+                                  //              = {val_a:"a", val_b:"b", shared_key:"from_a", _inc:[B]}
+                                  //  processed.delete(A_path)
+                                  //  return currentContextA
+
+            "_jinjer_include_contexts": ["main_circular_a.json"] // From main_circular_b.json, as it's merged last into A (and its include of A is skipped)
+                                                              // No, from the trace above, it should be _inc:[B] from A, which was itself from B's include of A, then merged.
+                                                              // The final A is merged with (B merged with raw A).
+                                                              // So A's original _inc:[B] is merged with B's _inc:[B] (which came from raw A). Result: _inc:[B]
+        };
+         assert.deepStrictEqual(contextUsed, {
+            "val_a": "a",
+            "val_b": "b",
+            "shared_key": "from_a", // Correct from the detailed trace.
+            "_jinjer_include_contexts": ["main_circular_b.json"] // Corrected based on detailed trace.
+        });
+
+
+        // Check that a warning for circular dependency was logged
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(/Circular dependency detected/)), 'Expected console.warn for circular dependency');
+    });
+
+    test('Non-existent Include', async () => {
+        mockGlobalConfig['contextFile'] = 'main_non_existent_include.json';
+
+        const mainContent = { "mainVal": "main_val", "_jinjer_include_contexts": ["non_existent.json"] };
+        // non_existent.json is NOT added to mockFileContents
+
+        mockFileContents.set(getFixtureUri('main_non_existent_include.json').fsPath, JSON.stringify(mainContent));
+
+        const consoleWarnSpy = sinon.spy(console, 'warn');
+        spies.push(consoleWarnSpy);
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ mainVal }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        // Expected: mainContent is loaded, the include of non_existent.json is skipped.
+        assert.deepStrictEqual(contextUsed, mainContent);
+
+        // Check that a warning for the missing file was logged
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(/Included context file not found/)), 'Expected console.warn for missing include file');
+        assert.ok(consoleWarnSpy.calledWith(sinon.match(/non_existent.json/)), 'Expected non_existent.json to be mentioned in the warning');
+    });
+
+    test('Include YAML from JSON', async () => {
+        mockGlobalConfig['contextFile'] = 'main_include_yaml.json';
+
+        const mainContent = { "mainJsonVal": "main_json_val", "_jinjer_include_contexts": ["data.yaml"] };
+        const yamlContentString = `yamlVal: "yaml_val"\notherYamlKey: "other_yaml_key_val"`; // Raw YAML string
+        const expectedYamlParsed = { yamlVal: "yaml_val", otherYamlKey: "other_yaml_key_val" };
+
+
+        mockFileContents.set(getFixtureUri('main_include_yaml.json').fsPath, JSON.stringify(mainContent));
+        mockFileContents.set(getFixtureUri('data.yaml').fsPath, yamlContentString); // Store raw YAML string
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        await setupAndPreview('{{ mainJsonVal }} {{ yamlVal }} {{ otherYamlKey }}', 'dummy.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainJsonVal": "main_json_val",
+            ...expectedYamlParsed, // Spread the parsed YAML content
+            "_jinjer_include_contexts": ["data.yaml"]
+        };
+        assert.deepStrictEqual(contextUsed, expectedContext);
+    });
+
+    test('Absolute Path Include (mocked as absolute)', async () => {
+        mockGlobalConfig['contextFile'] = 'main_absolute_include.json';
+        const includePathString = '/abs_path_to/absolute_target.json'; // Path that isAbsolute will be true for
+
+        const mainContent = { "mainVal": "main_abs_val", "_jinjer_include_contexts": [includePathString] };
+        const absoluteTargetContent = { "absTargetVal": "abs_target_val" };
+
+        // Main file is relative to testFixtureRoot
+        mockFileContents.set(getFixtureUri('main_absolute_include.json').fsPath, JSON.stringify(mainContent));
+        // The "absolute" file's content is keyed by the exact path string used in the include
+        mockFileContents.set(includePathString, JSON.stringify(absoluteTargetContent));
+
+
+        // Stub path.isAbsolute for this test case
+        const pathIsAbsoluteStub = sinon.stub(path, 'isAbsolute').callsFake((p: string) => {
+            if (p === includePathString) {
+                return true;
+            }
+            // Fallback to original for other paths if any are checked (though unlikely in this specific code path)
+            // For a more robust stub, you might need to call original `path.isAbsolute` for other paths.
+            // However, loadContextRecursive only calls it for includePathString.
+            return false; // Default for any other path it might be called with in this test's context.
+        });
+        stubs.push(pathIsAbsoluteStub); // Manage this stub for cleanup by the main teardown
+
+        const renderStringSpy = sinon.spy(nunjucks.Environment.prototype, 'renderString');
+        spies.push(renderStringSpy);
+
+        // The 'dummy_abs.j2' is just to provide a starting point for findContextFile.
+        // main_absolute_include.json will be found relative to testFixtureRoot.
+        await setupAndPreview('{{ mainVal }} {{ absTargetVal }}', 'dummy_abs.j2');
+
+        assert.ok(renderStringSpy.called, 'Nunjucks renderString was not called');
+        const contextUsed = renderStringSpy.lastCall.args[1];
+
+        const expectedContext = {
+            "mainVal": "main_abs_val",
+            "absTargetVal": "abs_target_val",
+            "_jinjer_include_contexts": [includePathString]
+        };
+        assert.deepStrictEqual(contextUsed, expectedContext);
+        assert.ok(pathIsAbsoluteStub.calledWith(includePathString), 'path.isAbsolute was not called with the include string');
+    });
+
+    // All context inclusion tests are now added.
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -159,7 +159,7 @@ class MockLanguageModelAccessInformation implements vscode.LanguageModelAccessIn
 // --- Main Test Suite ---
 suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
     const mockFileContents: Map<string, string> = new Map(); // Initialized
-    const mockGlobalConfig: { [key: string]: any } = {};   // Initialized
+    let mockGlobalConfig: { [key: string]: any } = {};   // Changed to let, initialized
 
     let mockWorkspaceConfig: any; // This is reset in each outer setup, so `let` is fine.
     let mockWorkspaceSettingsContent: string | undefined;
@@ -171,8 +171,10 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
     setup(() => {
         // Default mock states
         mockFileContents.clear();
+        // Reset mockGlobalConfig by clearing its properties
         Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
         // mockGlobalConfig can be seeded with common defaults here if necessary after clearing
+        // e.g., mockGlobalConfig.settingsFile = '.jinjer-settings.json';
 
         mockWorkspaceConfig = {}; // For workspace-level VS Code settings (distinct from .jinjer-settings.json)
         mockWorkspaceSettingsContent = undefined;
@@ -363,12 +365,12 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
         setup(() => {
             // Global settings that should be overridden
-            mockGlobalConfig = {
-                contextFile: 'global.context.json',
-                variableSuffix: 'g',
-                customSearchPath: 'global_includes', // This should be ignored
-                settingsFile: '.jinjer-settings.json' // Important for the test to pick up the file
-            };
+            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
+            mockGlobalConfig.contextFile = 'global.context.json';
+            mockGlobalConfig.variableSuffix = 'g';
+            mockGlobalConfig.customSearchPath = 'global_includes'; // This should be ignored
+            mockGlobalConfig.settingsFile = '.jinjer-settings.json'; // Important for the test to pick up the file
+
             mockFileContents.set(globalContextFilePath, JSON.stringify({ G_data: "From Global Context" }));
 
             // Workspace .jinjer-settings.json
@@ -447,14 +449,13 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
             mockFileContents.delete(path.join(mockWorkspaceFolder!.uri.fsPath, '.jinjer-settings.json'));
 
             // Ensure no relevant global settings
-            mockGlobalConfig = {
-                // settingsFile might be globally defined, but its target .jinjer-settings.json won't exist
-                settingsFile: '.jinjer-settings.json',
-                // Explicitly set others to undefined or ensure they are not in mockGlobalConfig
-                contextFile: undefined,
-                variableSuffix: undefined,
-                customSearchPath: undefined
-            };
+            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
+            // settingsFile might be globally defined, but its target .jinjer-settings.json won't exist
+            mockGlobalConfig.settingsFile = '.jinjer-settings.json';
+            // Explicitly set others to undefined or ensure they are not in mockGlobalConfig
+            mockGlobalConfig.contextFile = undefined;
+            mockGlobalConfig.variableSuffix = undefined;
+            mockGlobalConfig.customSearchPath = undefined;
 
             // Provide the default .jinjer.json context file
             mockFileContents.set(defaultContextFilePath, JSON.stringify({ default_data: "From Default .jinjer.json" }));
@@ -532,7 +533,8 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
 
         setup(() => {
             // Base settings for these tests - other settings like contextFile are not the focus here.
-            mockGlobalConfig = { settingsFile: '.jinjer-settings.json' };
+            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
+            mockGlobalConfig.settingsFile = '.jinjer-settings.json';
             mockFileContents.set(path.join(mockWorkspaceFolder!.uri.fsPath, '.jinjer.json'), JSON.stringify({ msg: "default" })); // Default context
         });
 
@@ -602,12 +604,12 @@ suite('Jinjer Extension - Per-Workspace Configuration Tests', () => {
             // For this test, explicitly not setting mockFileContents for '.jinjer-settings.json' is key.
 
             // Global settings that should be used
-            mockGlobalConfig = {
-                contextFile: 'global-fallback.context.json',
-                variableSuffix: 'gFallback',
-                customSearchPath: globalSearchPath,
-                settingsFile: '.jinjer-settings.json' // Extension will look for this, but it won't be found
-            };
+            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]);
+            mockGlobalConfig.contextFile = 'global-fallback.context.json';
+            mockGlobalConfig.variableSuffix = 'gFallback';
+            mockGlobalConfig.customSearchPath = globalSearchPath;
+            mockGlobalConfig.settingsFile = '.jinjer-settings.json'; // Extension will look for this, but it won't be found
+
             mockFileContents.set(globalContextFilePath, JSON.stringify({ GF_data: "From Global Fallback Context" }));
             mockFileContents.set(globalIncludeTemplatePath, "Included Content (Global Fallback Path)");
         });
@@ -753,22 +755,23 @@ suite('Context Inclusion Tests', () => {
     // `spies` array is from the outer suite for centralized cleanup.
 
     beforeEach(() => {
-        // Clear the mockFileContents from the outer suite.
+        // Clear the mockFileContents (from outer scope)
         if (mockFileContents && typeof mockFileContents.clear === 'function') {
             mockFileContents.clear();
         } else {
             // This case should ideally not happen if mockFileContents is correctly from the outer scope.
-            // console.warn("Context Inclusion Tests: Outer mockFileContents not found or not a Map.");
+            console.warn("Context Inclusion Tests beforeEach: mockFileContents not found or not a Map.");
         }
 
-        // Reset relevant parts of the outer mockGlobalConfig, or set defaults for this suite
+        // Reset relevant parts of the outer mockGlobalConfig for this suite's defaults
         if (mockGlobalConfig) {
-            mockGlobalConfig['contextIncludeKey'] = '_jinjer_include_contexts';
-            mockGlobalConfig['contextFile'] = 'context.json'; // Default for most tests
-            mockGlobalConfig['variableSuffix'] = ''; // No suffix by default
+            Object.keys(mockGlobalConfig).forEach(key => delete mockGlobalConfig[key]); // Clear properties first
+            mockGlobalConfig.contextIncludeKey = '_jinjer_include_contexts';
+            mockGlobalConfig.contextFile = 'context.json'; // Default for most tests in this suite
+            mockGlobalConfig.variableSuffix = ''; // No suffix by default for this suite
         } else {
             // This case should ideally not happen.
-            // console.warn("Context Inclusion Tests: Outer mockGlobalConfig not found.");
+            console.warn("Context Inclusion Tests beforeEach: mockGlobalConfig not found.");
         }
     });
 

--- a/src/test/testFixture/contextIncludes/base/main_relative_up.json
+++ b/src/test/testFixture/contextIncludes/base/main_relative_up.json
@@ -1,0 +1,4 @@
+{
+  "mainVal": "main_relative_up_val",
+  "_jinjer_include_contexts": ["../common_data.json"]
+}

--- a/src/test/testFixture/contextIncludes/common_data.json
+++ b/src/test/testFixture/contextIncludes/common_data.json
@@ -1,0 +1,3 @@
+{
+  "commonVal": "common_data_val"
+}

--- a/src/test/testFixture/contextIncludes/conflict_source.json
+++ b/src/test/testFixture/contextIncludes/conflict_source.json
@@ -1,0 +1,4 @@
+{
+  "key": "conflict_source_val",
+  "conflictOnlyKey": "conflict_only_val"
+}

--- a/src/test/testFixture/contextIncludes/data.yaml
+++ b/src/test/testFixture/contextIncludes/data.yaml
@@ -1,0 +1,2 @@
+yamlVal: "yaml_val"
+otherYamlKey: "other_yaml_key_val"

--- a/src/test/testFixture/contextIncludes/include1.json
+++ b/src/test/testFixture/contextIncludes/include1.json
@@ -1,0 +1,3 @@
+{
+  "inclVal": "included_val_1"
+}

--- a/src/test/testFixture/contextIncludes/level1.json
+++ b/src/test/testFixture/contextIncludes/level1.json
@@ -1,0 +1,4 @@
+{
+  "l1Val": "level1_val",
+  "_jinjer_include_contexts": ["level2.json"]
+}

--- a/src/test/testFixture/contextIncludes/level2.json
+++ b/src/test/testFixture/contextIncludes/level2.json
@@ -1,0 +1,3 @@
+{
+  "l2Val": "level2_val"
+}

--- a/src/test/testFixture/contextIncludes/main_circular_a.json
+++ b/src/test/testFixture/contextIncludes/main_circular_a.json
@@ -1,0 +1,4 @@
+{
+  "val_a": "value_a",
+  "_jinjer_include_contexts": ["main_circular_b.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_circular_b.json
+++ b/src/test/testFixture/contextIncludes/main_circular_b.json
@@ -1,0 +1,4 @@
+{
+  "val_b": "value_b",
+  "_jinjer_include_contexts": ["main_circular_a.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_conflict.json
+++ b/src/test/testFixture/contextIncludes/main_conflict.json
@@ -1,0 +1,5 @@
+{
+  "key": "main_conflict_val",
+  "mainOnlyKey": "main_only_val",
+  "_jinjer_include_contexts": ["conflict_source.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_empty_include.json
+++ b/src/test/testFixture/contextIncludes/main_empty_include.json
@@ -1,0 +1,4 @@
+{
+  "val": "main_empty_include_val",
+  "_jinjer_include_contexts": []
+}

--- a/src/test/testFixture/contextIncludes/main_include_yaml.json
+++ b/src/test/testFixture/contextIncludes/main_include_yaml.json
@@ -1,0 +1,4 @@
+{
+  "mainJsonVal": "main_json_val",
+  "_jinjer_include_contexts": ["data.yaml"]
+}

--- a/src/test/testFixture/contextIncludes/main_multi_level.json
+++ b/src/test/testFixture/contextIncludes/main_multi_level.json
@@ -1,0 +1,4 @@
+{
+  "mainVal": "main_multi_level_val",
+  "_jinjer_include_contexts": ["level1.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_no_include.json
+++ b/src/test/testFixture/contextIncludes/main_no_include.json
@@ -1,0 +1,3 @@
+{
+  "val": "main_no_include_val"
+}

--- a/src/test/testFixture/contextIncludes/main_non_existent_include.json
+++ b/src/test/testFixture/contextIncludes/main_non_existent_include.json
@@ -1,0 +1,4 @@
+{
+  "mainVal": "main_non_existent_val",
+  "_jinjer_include_contexts": ["non_existent.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_relative_path.json
+++ b/src/test/testFixture/contextIncludes/main_relative_path.json
@@ -1,0 +1,4 @@
+{
+  "mainVal": "main_relative_val",
+  "_jinjer_include_contexts": ["./subdir/relative.json"]
+}

--- a/src/test/testFixture/contextIncludes/main_single_include.json
+++ b/src/test/testFixture/contextIncludes/main_single_include.json
@@ -1,0 +1,4 @@
+{
+  "mainVal": "main_single_val",
+  "_jinjer_include_contexts": ["include1.json"]
+}

--- a/src/test/testFixture/contextIncludes/subdir/relative.json
+++ b/src/test/testFixture/contextIncludes/subdir/relative.json
@@ -1,0 +1,3 @@
+{
+  "relativeVal": "relative_subdir_val"
+}


### PR DESCRIPTION
Resolves #5 

This feature allows context files (JSON or YAML) to include other context files, enabling more modular and shared configurations.

A new VS Code setting `jinjer.contextIncludeKey` (default: `"_jinjer_include_contexts"`) defines a key within context files. This key should contain an array of strings, where each string is a path to another context file to be included.

Key functionalities:
- Paths can be relative (to the file containing the include key) or absolute.
- Included context files are deep-merged into the parent context.
- In case of conflicting keys, the "last win" strategy applies (values from later-included files or the parent file's own keys overwrite those from earlier ones if specified later in the merge sequence).
- Supports inclusion of both JSON and YAML files.
- Circular dependencies are detected and handled gracefully by preventing re-inclusion.
- The feature can be disabled by setting `jinjer.contextIncludeKey` to null or an empty string.

Comprehensive unit tests have been added to cover various scenarios, including different path types, merge behaviors, error conditions, and file types. The README.md has been updated to document this new feature and its usage.